### PR TITLE
feat: Add GitHub Action for cross-platform builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,76 @@
+name: Rust Cross-Platform Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+  PROJECT_NAME: rocker # Name of the binary (without .exe)
+
+jobs:
+  build:
+    name: Build for ${{ matrix.os_name }} (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - os_name: Linux
+            target: x86_64-unknown-linux-gnu
+            artifact_name: ${{ env.PROJECT_NAME }}-linux-amd64
+            asset_name: ${{ env.PROJECT_NAME }}-linux-amd64
+            use_cross: false
+          - os_name: Windows
+            target: x86_64-pc-windows-gnu
+            artifact_name: ${{ env.PROJECT_NAME }}-windows-amd64
+            asset_name: ${{ env.PROJECT_NAME }}-windows-amd64.exe
+            use_cross: false
+          - os_name: macOS-arm64
+            target: aarch64-apple-darwin
+            artifact_name: ${{ env.PROJECT_NAME }}-macos-arm64
+            asset_name: ${{ env.PROJECT_NAME }}-macos-arm64
+            use_cross: true
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: ${{ matrix.target }}
+
+    - name: Install dependencies for Windows cross-compilation (if applicable)
+      if: matrix.target == 'x86_64-pc-windows-gnu'
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y gcc-mingw-w64-x86-64
+        echo "[target.x86_64-pc-windows-gnu]" >> ${HOME}/.cargo/config.toml
+        echo "linker = "x86_64-w64-mingw32-gcc"" >> ${HOME}/.cargo/config.toml
+        echo "ar = "x86_64-w64-mingw32-ar"" >> ${HOME}/.cargo/config.toml
+
+    - name: Install cross (if applicable)
+      if: matrix.use_cross == true
+      run: cargo install cross --git https://github.com/cross-rs/cross --branch main
+
+    - name: Build binary
+      run: |
+        if [[ "${{ matrix.use_cross }}" == "true" ]]; then
+          cross build --release --target ${{ matrix.target }}
+        else
+          cargo build --release --target ${{ matrix.target }}
+        fi
+        SOURCE_PATH="target/${{ matrix.target }}/release/${{ env.PROJECT_NAME }}"
+        if [[ "${{ matrix.target }}" == "x86_64-pc-windows-gnu" ]]; then
+          SOURCE_PATH="${SOURCE_PATH}.exe"
+        fi
+        cp "${SOURCE_PATH}" "${{ matrix.asset_name }}"
+
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ matrix.artifact_name }}
+        path: ${{ matrix.asset_name }}
+        retention-days: 7


### PR DESCRIPTION
Creates a GitHub Action workflow in `.github/workflows/build.yml`.

This workflow builds the Rust project for the following targets:
- Linux amd64 (`x86_64-unknown-linux-gnu`)
- Windows amd64 (`x86_64-pc-windows-gnu` using MinGW)
- macOS arm64 (`aarch64-apple-darwin` using the `cross` tool)

All jobs run on `ubuntu-latest`. The workflow includes:
- Checking out code.
- Setting up the Rust toolchain and specified targets.
- Installing necessary dependencies for cross-compilation (MinGW for Windows, `cross` for macOS).
- Running `cargo build --release` (or `cross build`) for each target.
- Renaming the output binary to a consistent format (e.g., `rocker-linux-amd64`, `rocker-windows-amd64.exe`).
- Uploading the compiled binaries as artifacts for each job, retained for 7 days.

This action is triggered on pushes to the main branch and on pull requests targeting main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Introduced automated cross-platform builds for Linux, Windows, and macOS ARM64. Build artifacts are generated and uploaded for each platform on pushes and pull requests to the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->