### PR TITLE
Track A: player releases on the charts

### DIFF
--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -939,8 +939,8 @@ impl Game {
         Ok(())
     }
 
-    /// Expire a stale support offer, or roll for a new one from a rival act
-    /// famous enough to headline over you.
+    /// Expire a stale support offer, or roll for a new one from a bigger
+    /// scene act famous enough to headline over you.
     fn update_support_tour_offer(&mut self) {
         if let Some(offer) = &self.pending_support_offer {
             if self.week >= offer.expires_week {
@@ -1028,6 +1028,15 @@ impl Game {
                 let sales_score = self.calculate_release_sales_score(&release);
                 release.initial_sales_score = sales_score;
 
+                // The charts are a shared scoreboard: your record competes
+                // against the scene's releases on the same sales scale.
+                let chart_position = self.world.submit_chart_entry(
+                    release.name.clone(),
+                    self.band.name.clone(),
+                    true,
+                    sales_score,
+                );
+
                 let (income, units_sold, sold_out) = self.calculate_release_outcome(sales_score, &release);
                 release.total_income_generated += income;
                 release.copies_sold = units_sold;
@@ -1062,6 +1071,12 @@ impl Game {
                     self.log(format!(
                         "📦 '{}' sold out — all {} copies gone; demand was there for more.",
                         release.name, release.copies_pressed
+                    ));
+                }
+                if let Some(position) = chart_position {
+                    self.log(format!(
+                        "📈 '{}' enters the charts at #{}.",
+                        release.name, position
                     ));
                 }
 
@@ -1748,6 +1763,50 @@ mod tests {
 
         assert_eq!(game.band.fame, 30, "a record in its sales window counts as visibility");
         assert_eq!(game.idle_streak, 0);
+    }
+
+    #[test]
+    fn a_hit_release_enters_the_charts_and_a_flop_misses() {
+        let mut game = test_game();
+        game.initialize_player("Test", "The Tests");
+        // A crowded chart: ten scene records the player has to outsell.
+        for i in 0..world::CHART_SIZE {
+            game.world
+                .submit_chart_entry(format!("Scene Filler {i}"), "Scene Band".into(), false, 200);
+        }
+
+        // A famous band drops a great record...
+        game.band.fame = 80;
+        let mut hit = test_release(1, ReleaseType::Single);
+        hit.name = "Big Hit".to_string();
+        hit.release_quality = 90;
+        game.just_released_music.push(hit);
+        game.week = INITIAL_SALES_WINDOW_WEEKS; // the sales window has closed
+        game.process_music_releases_and_marketing();
+
+        assert!(
+            game.world.charts.iter().any(|e| e.is_player && e.title == "Big Hit"),
+            "a high-scoring release should land on the chart"
+        );
+        assert!(
+            game.turn_log.iter().any(|m| m.contains("enters the charts at #1")),
+            "charting should be reported to the player"
+        );
+
+        // ...while a nobody's dud sinks without a trace.
+        game.band.fame = 0;
+        let mut flop = test_release(2, ReleaseType::Single);
+        flop.name = "Total Flop".to_string();
+        flop.release_quality = 1;
+        flop.week_released = game.week;
+        game.just_released_music.push(flop);
+        game.week += INITIAL_SALES_WINDOW_WEEKS;
+        game.process_music_releases_and_marketing();
+
+        assert!(
+            !game.world.charts.iter().any(|e| e.title == "Total Flop"),
+            "a flop should not crack a crowded top 10"
+        );
     }
 
     #[test]

--- a/src/game/world.rs
+++ b/src/game/world.rs
@@ -390,16 +390,16 @@ impl GameWorld {
         }
 
         // New blood: refill hard when thin, trickle otherwise.
-        let mut arrivals = if self.bands.len() < SCENE_MIN_BANDS {
+        let mut newcomers = if self.bands.len() < SCENE_MIN_BANDS {
             SCENE_MIN_BANDS - self.bands.len()
         } else if self.bands.len() < SCENE_MAX_BANDS {
             rng.gen_range(0..=3)
         } else {
             0
         };
-        arrivals = arrivals.min(SCENE_MAX_BANDS - self.bands.len());
+        newcomers = newcomers.min(SCENE_MAX_BANDS - self.bands.len());
 
-        for _ in 0..arrivals {
+        for _ in 0..newcomers {
             let name = self.unique_band_name(data_files, rng);
             // Newcomers mostly chase whatever is currently hot.
             let genre = if rng.gen_bool(0.4) {

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -42,6 +42,7 @@ pub enum Screen {
     Main,
     Deals { selected: usize, detail: bool },
     SupportOffer,
+    Charts,
     MarketingRelease { selected: usize },
     MarketingCampaign { release_id: u32, release_name: String, selected: usize },
     File { mode: FileMode, input: String },
@@ -57,6 +58,7 @@ pub enum MenuKind {
     Action(GameAction),
     Deals,
     SupportTour,
+    Charts,
     Marketing,
     Save,
     Load,
@@ -255,6 +257,16 @@ impl App {
                 kind: MenuKind::Deals,
             },
             MenuEntry {
+                hotkey: 'c',
+                label: "Charts…",
+                detail: match game.world.charts.iter().position(|e| e.is_player) {
+                    Some(spot) => format!("you're at #{}!", spot + 1),
+                    None => "this week's top 10".into(),
+                },
+                enabled: true,
+                kind: MenuKind::Charts,
+            },
+            MenuEntry {
                 hotkey: 's',
                 label: "Save Game",
                 detail: String::new(),
@@ -351,6 +363,7 @@ impl App {
             Screen::Main => self.handle_main_key(key),
             Screen::Deals { .. } => self.handle_deals_key(key),
             Screen::SupportOffer => self.handle_support_offer_key(key),
+            Screen::Charts => self.handle_charts_key(key),
             Screen::MarketingRelease { .. } => self.handle_marketing_release_key(key),
             Screen::MarketingCampaign { .. } => self.handle_marketing_campaign_key(key),
             Screen::File { .. } => self.handle_file_key(key),
@@ -445,6 +458,7 @@ impl App {
                     self.push_log(LogKind::Ui, "No support slots on offer — get noticed by the bigger acts first.");
                 }
             }
+            MenuKind::Charts => self.screen = Screen::Charts,
             MenuKind::Marketing => {
                 if self.game.band.current_deal().is_some() {
                     self.push_log(LogKind::Ui, "Promotion is your label's job — their people are already on it.");
@@ -539,6 +553,12 @@ impl App {
                 self.dispatch(GameAction::DeclineSupportTour);
             }
             _ => {}
+        }
+    }
+
+    fn handle_charts_key(&mut self, key: KeyEvent) {
+        if key.code == KeyCode::Esc {
+            self.screen = Screen::Main;
         }
     }
 

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -23,6 +23,7 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
             match &app.screen {
                 Screen::Deals { .. } => draw_deals_modal(frame, app),
                 Screen::SupportOffer => draw_support_modal(frame, app),
+                Screen::Charts => draw_charts_modal(frame, app),
                 Screen::MarketingRelease { .. } | Screen::MarketingCampaign { .. } => {
                     draw_marketing_modal(frame, app)
                 }
@@ -85,8 +86,9 @@ fn draw_setup(frame: &mut Frame, app: &App) {
 // --- Main screen ---
 
 fn draw_main(frame: &mut Frame, app: &mut App) {
+    // The stats band fits the scene panel's eight lines (chart line included).
     let [header_area, stats_area, bottom_area] =
-        Layout::vertical([Constraint::Length(4), Constraint::Length(10), Constraint::Min(8)])
+        Layout::vertical([Constraint::Length(4), Constraint::Length(11), Constraint::Min(8)])
             .areas(frame.area());
 
     draw_header(frame, &app.game, header_area);
@@ -286,18 +288,28 @@ fn draw_scene_panel(frame: &mut Frame, game: &Game, area: Rect) {
         .map(|b| format!("{} ({}%)", b.name, b.fame))
         .unwrap_or_else(|| "nobody".to_string());
 
-    let lines = vec![
+    let mut lines = vec![
         Line::from(format!("Trend      {}", game.world.current_trends)),
         Line::from(format!("Demand     {}%", game.world.music_market.demand)),
         Line::from(format!("Economy    {}", game.world.music_market.economic_state)),
         Line::from(format!("Innovation {}%", era.market_conditions.innovation_openness)),
         Line::from(format!("Bands      {} in the scene", game.world.bands.len())),
         Line::from(format!("Top Act    {}", top_band)),
-        Line::from(Span::styled(
-            format!("Hot: {}", era.dominant_genres.join(", ")),
-            Style::new().fg(Color::Cyan),
-        )),
     ];
+    // The reigning #1 record — in your colours when it's yours, and absent
+    // entirely while the charts are still empty.
+    if let Some(hit) = game.world.charts.first() {
+        let text = format!("No. 1      '{}' — {}", hit.title, hit.band_name);
+        lines.push(if hit.is_player {
+            Line::styled(text, Style::new().fg(ACCENT).bold())
+        } else {
+            Line::from(text)
+        });
+    }
+    lines.push(Line::from(Span::styled(
+        format!("Hot: {}", era.dominant_genres.join(", ")),
+        Style::new().fg(Color::Cyan),
+    )));
     frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), inner);
 }
 
@@ -420,6 +432,55 @@ fn draw_deals_modal(frame: &mut Frame, app: &App) {
         let mut state = ListState::default().with_selected(Some(*selected));
         frame.render_stateful_widget(list, area, &mut state);
     }
+}
+
+fn draw_charts_modal(frame: &mut Frame, app: &App) {
+    let area = centered_rect(72, 60, frame.area());
+    frame.render_widget(Clear, area);
+    let block = Block::bordered()
+        .title(" 📈 This Week's Top 10 ")
+        .title_style(Style::new().fg(Color::Yellow).bold())
+        .title_bottom(" Esc close ");
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let charts = &app.game.world.charts;
+    if charts.is_empty() {
+        let lines = vec![
+            Line::from(""),
+            Line::from("The charts are quiet — nobody's record is moving this week.").centered(),
+            Line::from("Put something out and claim a spot.").centered(),
+        ];
+        frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
+        return;
+    }
+
+    let mut lines = vec![Line::from("")];
+    for (idx, entry) in charts.iter().enumerate() {
+        // Your own records burn in the accent colour with a star.
+        let (style, marker) = if entry.is_player {
+            (Style::new().fg(ACCENT).bold(), "★")
+        } else {
+            (Style::new().fg(Color::White), " ")
+        };
+        let weeks = if entry.weeks_on_chart == 0 {
+            "NEW".to_string()
+        } else {
+            format!(
+                "{} wk{}",
+                entry.weeks_on_chart,
+                if entry.weeks_on_chart == 1 { "" } else { "s" }
+            )
+        };
+        lines.push(Line::from(vec![
+            Span::styled(format!("  #{:<3}", idx + 1), style),
+            Span::styled(format!("{} ", marker), style),
+            Span::styled(format!("{:<28}", format!("'{}'", entry.title)), style),
+            Span::styled(format!("{:<24}", entry.band_name), style),
+            Span::styled(weeks, style),
+        ]));
+    }
+    frame.render_widget(Paragraph::new(lines), inner);
 }
 
 fn draw_support_modal(frame: &mut Frame, app: &App) {


### PR DESCRIPTION
HANDOFF.md Track A. **Merge order: this one first.**

- Player releases now enter the weekly top-10 when their sales window closes (`submit_chart_entry` with `is_player = true`), with an in-fiction log line for the chart position.
- Charts modal on hotkey `c`: top 10 with position, title, band, weeks-on-chart ("NEW" for debuts); player rows highlighted with a ★ in the accent color. Menu detail shows "you're at #N!" while charting.
- Scene panel shows the current No. 1 record next to the top act.
- Terminology sweep complete: `rg -i rival src/` now matches only the intentional doc comment (includes an `arrivals` → `newcomers` rename that the substring match required).

Verification: 26 tests pass (new: `a_hit_release_enters_the_charts_and_a_flop_misses`, driven through the real release pipeline), clippy zero warnings, render path exercised via a ratatui TestBackend and a scripted TUI run.

Coordinator note: independently re-verified in an isolated build (26/26, clippy clean); merges cleanly with Track C in either order (pre-checked with merge-tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)