### PR TITLE
Track C: genre identity for the player's band

### DIFF
--- a/src/game/band.rs
+++ b/src/game/band.rs
@@ -1,9 +1,13 @@
 use serde::{Deserialize, Serialize};
 use super::music::{Song, Release}; // Import new structs
+use super::world::MusicGenre;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Band {
     pub name: String,
+    /// The sound the band plays. Saves from before genres existed load as Rock.
+    #[serde(default)]
+    pub genre: MusicGenre,
     pub fame: u8,  // 0-100
     pub skill: u8, // 0-100
     pub unreleased_songs: Vec<Song>,
@@ -61,6 +65,7 @@ impl Default for Band {
     fn default() -> Self {
         Self {
             name: String::new(),
+            genre: MusicGenre::Rock,
             fame: 0,
             skill: 20,
             unreleased_songs: Vec::new(),

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -82,6 +82,12 @@ const IDLE_GRACE_WEEKS: u32 = 1;
 const IDLE_FAME_DECAY_PER_WEEK: u8 = 1;
 pub const BREAK_WEEKS: u32 = 4;
 
+// Era-genre fit: past these bounds the era clearly loves or has abandoned
+// the band's sound, and the press says so — once per swing, not every week.
+// (A genre missing from an era's table reads as out of fashion at 0.85.)
+const GENRE_TREND_HOT: f32 = 1.15;
+const GENRE_TREND_COLD: f32 = 0.85;
+
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum GameAction {
@@ -136,6 +142,10 @@ pub struct Game {
     /// Consecutive weeks with no public activity (no shows, nothing on sale).
     #[serde(default)]
     pub idle_streak: u32,
+    /// The last era-fit verdict the press reported on the band's genre
+    /// (-1 cold, 0 unremarkable, +1 hot) — the news speaks only on change.
+    #[serde(default)]
+    pub genre_trend_reported: i8,
     pub week: u32,
     pub game_over: bool,
     pub next_song_id: u32,
@@ -174,6 +184,7 @@ impl Game {
             pending_support_offer: None,
             regional_fame: std::collections::HashMap::new(),
             idle_streak: 0,
+            genre_trend_reported: 0,
             week: 1,
             game_over: false,
             next_song_id: 0,
@@ -297,8 +308,13 @@ impl Game {
             .and_then(|g| self.world.dynamic_genre_modifiers.get(g).copied())
             .unwrap_or(1.0);
 
+        // The era's tastes: the same modifier scene-band releases live by.
+        let era_genre_modifier = release.genre.as_ref()
+            .map(|g| self.data_files.era_genre_modifier(self.timeline.get_current_year(), g.aliases()))
+            .unwrap_or(1.0);
+
         let base_score = quality_score + marketing_score + fame_score;
-        (base_score * era_sales_modifier * genre_modifier).max(0.0) as u32
+        (base_score * era_sales_modifier * genre_modifier * era_genre_modifier).max(0.0) as u32
     }
 
     /// How much of a release's potential audience the band can actually reach.
@@ -469,7 +485,7 @@ impl Game {
             marketing_level_achieved: 0,
             initial_sales_score: 0,
             total_income_generated: 0,
-            genre: selected_songs.first().map(|_s| world::MusicGenre::Rock), // Placeholder
+            genre: Some(self.band.genre.clone()),
             copies_pressed: copies,
             copies_sold: 0,
         };
@@ -529,7 +545,7 @@ impl Game {
             marketing_level_achieved: 0,
             initial_sales_score: 0,
             total_income_generated: 0,
-            genre: selected_songs.first().map(|_s| world::MusicGenre::Rock), // Placeholder
+            genre: Some(self.band.genre.clone()),
             copies_pressed: copies,
             copies_sold: 0,
         };
@@ -1143,6 +1159,37 @@ impl Game {
         }
     }
 
+    /// When the era clearly loves — or has clearly abandoned — the band's
+    /// sound, the press notices. Said once per swing, not every week.
+    fn update_genre_trend_news(&mut self) {
+        let era_fit = self
+            .data_files
+            .era_genre_modifier(self.timeline.get_current_year(), self.band.genre.aliases());
+        let verdict: i8 = if era_fit >= GENRE_TREND_HOT {
+            1
+        } else if era_fit <= GENRE_TREND_COLD {
+            -1
+        } else {
+            0
+        };
+        if verdict == self.genre_trend_reported {
+            return;
+        }
+        self.genre_trend_reported = verdict;
+        let genre = self.band.genre.name();
+        match verdict {
+            1 => self.log(format!(
+                "🎸 {} is exploding — you're in the right scene at the right time.",
+                genre
+            )),
+            -1 => self.log(format!(
+                "🥶 {} is out of step with the times — the crowds are chasing a different sound.",
+                genre
+            )),
+            _ => {}
+        }
+    }
+
     fn advance_week_events(&mut self) -> Result<(), String> {
         // Sync the timeline with the current week. Tours can jump several weeks
         // at once, so catch up year by year instead of testing a single boundary.
@@ -1154,6 +1201,7 @@ impl Game {
             let era_name = self.timeline.get_current_era().era_name.clone();
             self.log(format!("🗓️ It's now {} — the era of {}.", year, era_name));
         }
+        self.update_genre_trend_news();
 
         if let Some(event) = self.events.try_trigger_event(self.week) {
             self.apply_random_event(event)?;
@@ -1870,6 +1918,84 @@ mod tests {
         let offer = game.pending_support_offer.as_ref().unwrap();
         assert!(offer.host_fame >= game.band.fame + SUPPORT_OFFER_FAME_GAP);
         assert!(offer.pay > 0);
+    }
+
+    #[test]
+    fn a_release_riding_the_era_outsells_one_against_it() {
+        let mut game = test_game();
+        game.band.fame = 40;
+        game.world.dynamic_genre_modifiers.clear(); // era taste is the only genre input
+
+        let year = game.timeline.get_current_year();
+        let era_fit =
+            |genre: &world::MusicGenre| game.data_files.era_genre_modifier(year, genre.aliases());
+        let hot = world::MusicGenre::ALL
+            .iter()
+            .max_by(|a, b| era_fit(a).total_cmp(&era_fit(b)))
+            .expect("genres exist")
+            .clone();
+        let cold = world::MusicGenre::ALL
+            .iter()
+            .min_by(|a, b| era_fit(a).total_cmp(&era_fit(b)))
+            .expect("genres exist")
+            .clone();
+        assert!(era_fit(&hot) > era_fit(&cold), "the era should actually have tastes");
+
+        let mut on_trend = test_release(1, ReleaseType::Single);
+        on_trend.genre = Some(hot);
+        let mut against_the_grain = test_release(2, ReleaseType::Single);
+        against_the_grain.genre = Some(cold);
+
+        assert!(
+            game.calculate_release_sales_score(&on_trend)
+                > game.calculate_release_sales_score(&against_the_grain),
+            "identical records should sell by the era's tastes"
+        );
+    }
+
+    #[test]
+    fn bands_saved_before_genres_existed_load_as_rock() {
+        assert_eq!(Band::default().genre, world::MusicGenre::Rock);
+
+        // A pre-genre save is a Band JSON object with no "genre" key at all.
+        let mut saved = serde_json::to_value(Band::default()).expect("bands serialize");
+        saved
+            .as_object_mut()
+            .expect("a band serializes to an object")
+            .remove("genre");
+        let loaded: Band = serde_json::from_value(saved).expect("old saves must keep loading");
+        assert_eq!(loaded.genre, world::MusicGenre::Rock);
+    }
+
+    #[test]
+    fn the_press_calls_a_hot_genre_once_not_weekly() {
+        let mut game = test_game();
+        // Rock is the sound of 1970 in the era data — clearly hot.
+        game.band.genre = world::MusicGenre::Rock;
+
+        game.process_turn(GameAction::LazeAround).expect("lazing always works");
+        game.process_turn(GameAction::LazeAround).expect("lazing always works");
+
+        let mentions = game
+            .turn_log
+            .iter()
+            .filter(|line| line.contains("right scene at the right time"))
+            .count();
+        assert_eq!(mentions, 1, "the trend is news once, not every week");
+    }
+
+    #[test]
+    fn the_press_notices_a_genre_the_era_left_behind() {
+        let mut game = test_game();
+        // Punk is years ahead of 1970's tastes — out of fashion on day one.
+        game.band.genre = world::MusicGenre::Punk;
+
+        game.process_turn(GameAction::LazeAround).expect("lazing always works");
+
+        assert!(
+            game.turn_log.iter().any(|line| line.contains("chasing a different sound")),
+            "an off-trend band should hear about it"
+        );
     }
 
     #[test]

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -202,9 +202,10 @@ impl Game {
         std::mem::take(&mut self.turn_log)
     }
 
-    pub fn initialize_player(&mut self, player_name: &str, band_name: &str) {
+    pub fn initialize_player(&mut self, player_name: &str, band_name: &str, genre: world::MusicGenre) {
         self.player.name = player_name.to_string();
         self.band.name = band_name.to_string();
+        self.band.genre = genre;
         self.player.money = 500; // Starting cash in 1970
 
         self.band.members = vec![
@@ -1801,7 +1802,7 @@ mod tests {
     #[test]
     fn a_full_season_of_turns_never_panics() {
         let mut game = test_game();
-        game.initialize_player("Test", "The Tests");
+        game.initialize_player("Test", "The Tests", world::MusicGenre::Rock);
         for i in 0..30 {
             let action = match i % 6 {
                 0 => GameAction::WriteSongs,

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -3,6 +3,7 @@ use ratatui::crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, Ke
 
 use crate::data::constants;
 use crate::game::music::{MarketingCampaignType, ReleaseType};
+use crate::game::world::MusicGenre;
 use crate::game::{BREAK_WEEKS, Game, GameAction, PRESSING_TIERS};
 
 use super::render;
@@ -29,6 +30,7 @@ pub struct LogEntry {
 pub enum SetupField {
     Name,
     BandName,
+    Genre,
 }
 
 #[derive(Clone, Copy)]
@@ -90,6 +92,7 @@ pub struct App {
     pub menu_selected: usize,
     pub name_input: String,
     pub band_input: String,
+    pub genre_selected: usize,
     should_exit: bool,
 }
 
@@ -102,6 +105,7 @@ impl App {
             menu_selected: 0,
             name_input: String::new(),
             band_input: String::new(),
+            genre_selected: 0,
             should_exit: false,
         }
     }
@@ -363,43 +367,69 @@ impl App {
 
     fn handle_setup_key(&mut self, key: KeyEvent) {
         let Screen::Setup { field } = self.screen else { return };
-        let input = match field {
-            SetupField::Name => &mut self.name_input,
-            SetupField::BandName => &mut self.band_input,
-        };
 
-        match key.code {
-            KeyCode::Char(c) if input.len() < INPUT_MAX_LEN => input.push(c),
-            KeyCode::Backspace => {
-                input.pop();
-            }
-            KeyCode::Esc => self.should_exit = true,
-            KeyCode::Enter => {
-                if input.trim().is_empty() {
-                    return;
-                }
-                match field {
-                    SetupField::Name => {
-                        self.screen = Screen::Setup { field: SetupField::BandName };
-                    }
-                    SetupField::BandName => {
-                        let name = self.name_input.trim().to_string();
-                        let band = self.band_input.trim().to_string();
-                        self.game.initialize_player(&name, &band);
-                        self.push_log(
-                            LogKind::Ui,
-                            format!("Welcome to {}, {}. Make '{}' a legend.", constants::STARTING_YEAR, name, band),
-                        );
-                        self.push_log(
-                            LogKind::Ui,
-                            "Tip: hotkeys act instantly — V reviews deal offers, M runs marketing.",
-                        );
-                        self.screen = Screen::Main;
-                    }
-                }
-            }
-            _ => {}
+        if key.code == KeyCode::Esc {
+            self.should_exit = true;
+            return;
         }
+
+        match field {
+            SetupField::Name | SetupField::BandName => {
+                let input = match field {
+                    SetupField::Name => &mut self.name_input,
+                    _ => &mut self.band_input,
+                };
+                match key.code {
+                    KeyCode::Char(c) if input.len() < INPUT_MAX_LEN => input.push(c),
+                    KeyCode::Backspace => {
+                        input.pop();
+                    }
+                    KeyCode::Enter if !input.trim().is_empty() => {
+                        let next = if field == SetupField::Name {
+                            SetupField::BandName
+                        } else {
+                            SetupField::Genre
+                        };
+                        self.screen = Screen::Setup { field: next };
+                    }
+                    _ => {}
+                }
+            }
+            SetupField::Genre => {
+                let count = MusicGenre::ALL.len();
+                match key.code {
+                    KeyCode::Up | KeyCode::Char('k') => {
+                        self.genre_selected = self.genre_selected.checked_sub(1).unwrap_or(count - 1);
+                    }
+                    KeyCode::Down | KeyCode::Char('j') => {
+                        self.genre_selected = (self.genre_selected + 1) % count;
+                    }
+                    KeyCode::Enter => self.finish_setup(),
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    /// Hand the chosen identity to the game and start playing.
+    fn finish_setup(&mut self) {
+        let name = self.name_input.trim().to_string();
+        let band = self.band_input.trim().to_string();
+        let genre = MusicGenre::ALL[self.genre_selected.min(MusicGenre::ALL.len() - 1)].clone();
+        let genre_name = genre.name();
+        self.game.initialize_player(&name, &band, genre);
+        self.push_log(
+            LogKind::Ui,
+            format!(
+                "Welcome to {}, {}. Make '{}' the biggest name in {}.",
+                constants::STARTING_YEAR, name, band, genre_name
+            ),
+        );
+        self.push_log(
+            LogKind::Ui,
+            "Tip: hotkeys act instantly — V reviews deal offers, M runs marketing.",
+        );
+        self.screen = Screen::Main;
     }
 
     fn handle_main_key(&mut self, key: KeyEvent) {
@@ -744,6 +774,41 @@ impl App {
                 }
             }
             _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn press(app: &mut App, code: KeyCode) {
+        app.handle_setup_key(KeyEvent::new(code, KeyModifiers::empty()));
+    }
+
+    fn type_text(app: &mut App, text: &str) {
+        for c in text.chars() {
+            press(app, KeyCode::Char(c));
+        }
+    }
+
+    #[test]
+    fn setup_can_found_a_band_in_every_genre() {
+        for (index, genre) in MusicGenre::ALL.iter().enumerate() {
+            let mut app = App::new(Game::new().expect("data files present"));
+
+            type_text(&mut app, "Ray");
+            press(&mut app, KeyCode::Enter);
+            type_text(&mut app, "The Rayguns");
+            press(&mut app, KeyCode::Enter);
+            for _ in 0..index {
+                press(&mut app, KeyCode::Down);
+            }
+            press(&mut app, KeyCode::Enter);
+
+            assert!(matches!(app.screen, Screen::Main), "setup should end on the main screen");
+            assert_eq!(app.game.band.genre, *genre);
+            assert_eq!(app.game.band.name, "The Rayguns");
         }
     }
 }

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -8,6 +8,7 @@ use ratatui::{
 
 use crate::data::{calculate_weeks_to_years_months, constants, format_money};
 use crate::game::music::{MarketingCampaignType, ReleaseType};
+use crate::game::world::MusicGenre;
 use crate::game::{Game, PRESSING_TIERS};
 
 use super::app::{App, FileMode, LogKind, Screen, SetupField};
@@ -39,15 +40,16 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
 // --- Setup ---
 
 fn draw_setup(frame: &mut Frame, app: &App) {
-    let area = centered_rect(60, 50, frame.area());
+    let Screen::Setup { field } = &app.screen else { return };
+    let picking_genre = *field == SetupField::Genre;
+
+    // The genre list needs more room than the two name prompts.
+    let area = centered_rect(60, if picking_genre { 75 } else { 50 }, frame.area());
     let block = Block::bordered()
         .title(" 🎸 ROCKER ")
         .title_style(Style::new().fg(ACCENT).bold());
     let inner = block.inner(area);
     frame.render_widget(block, area);
-
-    let Screen::Setup { field } = &app.screen else { return };
-    let name_active = *field == SetupField::Name;
 
     let field_line = |label: &str, value: &str, active: bool| -> Line<'static> {
         let cursor = if active { "█" } else { "" };
@@ -62,7 +64,7 @@ fn draw_setup(frame: &mut Frame, app: &App) {
         ])
     };
 
-    let lines = vec![
+    let mut lines = vec![
         Line::from(""),
         Line::styled("R  O  C  K  E  R", Style::new().fg(ACCENT).bold()).centered(),
         Line::styled(
@@ -73,11 +75,33 @@ fn draw_setup(frame: &mut Frame, app: &App) {
         Line::from(""),
         Line::from("The Beatles just broke up. The stage is yours.").centered(),
         Line::from(""),
-        field_line("Your name:", &app.name_input, name_active),
-        field_line("Band name:", &app.band_input, !name_active),
-        Line::from(""),
-        Line::styled("Enter to confirm · Esc to quit", Style::new().fg(Color::DarkGray)).centered(),
+        field_line("Your name:", &app.name_input, *field == SetupField::Name),
+        field_line("Band name:", &app.band_input, *field == SetupField::BandName),
     ];
+
+    if picking_genre {
+        lines.push(Line::from(""));
+        lines.push(Line::styled("What do you play?", Style::new().fg(Color::Yellow).bold()));
+        for (i, genre) in MusicGenre::ALL.iter().enumerate() {
+            let (marker, style) = if i == app.genre_selected {
+                ("▸", Style::new().fg(Color::Yellow).bold())
+            } else {
+                (" ", Style::new().fg(Color::DarkGray))
+            };
+            lines.push(Line::styled(format!("  {} {}", marker, genre.name()), style));
+        }
+        lines.push(Line::from(""));
+        lines.push(
+            Line::styled("↑↓ choose · Enter confirm · Esc quit", Style::new().fg(Color::DarkGray))
+                .centered(),
+        );
+    } else {
+        lines.push(Line::from(""));
+        lines.push(
+            Line::styled("Enter to confirm · Esc to quit", Style::new().fg(Color::DarkGray))
+                .centered(),
+        );
+    }
 
     frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
 }


### PR DESCRIPTION
HANDOFF.md Track C — the thin bridge, not FUTURE.md §2. **Merge after Track A** (pre-checked: merges cleanly on top of it).

- `Band.genre: MusicGenre` (`#[serde(default)]` — old saves load as Rock).
- Setup gains a third step: pick your genre from all 8 (↑/↓/j/k + Enter), echoed in the welcome line.
- Releases are stamped with the band's genre instead of the hardcoded-Rock placeholder.
- Era tastes now hit player sales: `era_genre_modifier(year, aliases)` multiplied into the sales score (dynamic modifier and weights untouched; genre-less legacy releases get 1.0).
- Press nudges once per swing when your genre turns hot (≥1.15) or cold (≤0.85), state persisted so save/load doesn't re-announce.

Verification: 30 tests pass (5 new, incl. `a_release_riding_the_era_outsells_one_against_it` derived from the era data rather than hardcoded genres, and a setup test driving the real key handler through all 8 genres), clippy zero warnings, full TUI run via expect.

Coordinator note: independently re-verified in an isolated build (30/30, clippy clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)