### PR TITLE
Track F: label tiers actually scout you, and offers expire

### DIFF
--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -65,6 +65,12 @@ const SUPPORT_OFFER_MIN_FAME: u8 = 5;
 const SUPPORT_OFFER_FAME_GAP: u8 = 10;
 const SUPPORT_OFFER_CHANCE: f64 = 0.06;
 const SUPPORT_OFFER_LIFETIME_WEEKS: u32 = 3;
+
+// Record deals stay on the table about a month — one scouting cycle — so
+// a slate the player sits on clears just as labels next come looking, and
+// ignoring an offer can never silence the deal stream for good.
+const DEAL_OFFER_LIFETIME_WEEKS: u32 = 4;
+
 const PLAYER_MARKET_IMPACT_THRESHOLD_SALES_SCORE: u32 = 600;
 const PLAYER_MARKET_IMPACT_GENRE_MOD_BONUS: f32 = 0.05;
 const PLAYER_MARKET_IMPACT_DEMAND_BONUS: u8 = 1;
@@ -1247,10 +1253,35 @@ impl Game {
         Ok(())
     }
 
+    /// Quietly withdraw deal offers the player sat past their deadline.
+    /// Losing interest is not a rejection: nobody poaches the vacated deal
+    /// (that stays a consequence of `action_reject_deal` alone), and the
+    /// cleared slate lets labels come knocking again. Offers from saves
+    /// that predate expiry (`expires_week: None`) stay on the table
+    /// forever, exactly as they always did.
+    fn expire_stale_deal_offers(&mut self) {
+        let week = self.week;
+        let offers = std::mem::take(&mut self.pending_deal_offers);
+        let (expired, live): (Vec<_>, Vec<_>) = offers
+            .into_iter()
+            .partition(|offer| offer.expires_week.is_some_and(|deadline| week >= deadline));
+        self.pending_deal_offers = live;
+        for offer in expired {
+            self.log(format!(
+                "📪 {}'s interest has cooled — their offer is off the table.",
+                offer.label_name
+            ));
+        }
+    }
+
     fn check_and_generate_deal_offers(&mut self) {
+        self.expire_stale_deal_offers();
         if self.pending_deal_offers.is_empty() && self.week.is_multiple_of(4) && self.band.record_deal.is_none() {
             let mut rng = rand::thread_rng();
-            let new_offers = self.world.generate_deal_offers(&self.band, &self.data_files, &mut rng);
+            let mut new_offers = self.world.generate_deal_offers(&self.band, &self.data_files, &mut rng);
+            for offer in &mut new_offers {
+                offer.expires_week = Some(self.week + DEAL_OFFER_LIFETIME_WEEKS);
+            }
             if !new_offers.is_empty() {
                 let n = new_offers.len();
                 self.pending_deal_offers = new_offers;
@@ -2078,5 +2109,82 @@ mod tests {
             game.turn_log.iter().any(|m| m.contains("went to another band")),
             "expiry should be reported"
         );
+    }
+
+    /// A pending offer as `check_and_generate_deal_offers` would leave it.
+    fn test_deal_offer(game: &Game, expires_week: Option<u32>) -> PotentialDealOffer {
+        let label = game.data_files.get_record_labels_data().independent_labels[0].clone();
+        PotentialDealOffer {
+            label_name: label.name.clone(),
+            label_tier: "Independent".to_string(),
+            advance: 1_000,
+            royalty_rate: 0.12,
+            albums_required: 1,
+            original_label_data: label,
+            expires_week,
+        }
+    }
+
+    #[test]
+    fn ignored_deal_offers_expire_and_the_stream_resumes() {
+        let mut game = test_game();
+        game.pending_deal_offers = vec![test_deal_offer(&game, Some(8))];
+        let unsigned_before = game.world.bands.iter().filter(|b| b.label.is_none()).count();
+
+        // Before the deadline the offer stays on the table.
+        game.week = 7;
+        game.check_and_generate_deal_offers();
+        assert_eq!(game.pending_deal_offers.len(), 1, "a live offer survives to its deadline");
+
+        // At the deadline it quietly leaves — with a line in the log...
+        game.week = 8;
+        game.check_and_generate_deal_offers();
+        assert!(game.pending_deal_offers.is_empty(), "an ignored offer should expire");
+        let log = game.take_turn_log().join("\n");
+        assert!(log.contains("interest has cooled"), "expiry is told in-fiction, got: {log}");
+        // ...and, unlike a rejection, nobody poaches the vacated deal.
+        let unsigned_after = game.world.bands.iter().filter(|b| b.label.is_none()).count();
+        assert_eq!(
+            unsigned_before, unsigned_after,
+            "expiry must not hand the deal to a scene act"
+        );
+
+        // With the slate clear and a catalog worth scouting, the stream
+        // resumes on the next 4-week beat instead of staying silent forever.
+        game.band.fame = 30;
+        game.band.singles_released.push(test_release(1, ReleaseType::Single));
+        let mut resumed = false;
+        for _ in 0..80 {
+            game.check_and_generate_deal_offers();
+            if !game.pending_deal_offers.is_empty() {
+                resumed = true;
+                break;
+            }
+        }
+        assert!(resumed, "new offers should arrive once the slate is clear");
+        assert!(
+            game.pending_deal_offers
+                .iter()
+                .all(|offer| offer.expires_week == Some(game.week + DEAL_OFFER_LIFETIME_WEEKS)),
+            "fresh offers should carry a deadline"
+        );
+    }
+
+    #[test]
+    fn deal_offers_from_old_saves_never_expire() {
+        // Offers already pending when an old save was written carry no
+        // deadline; they stay on the table however late it gets.
+        let mut game = test_game();
+        game.pending_deal_offers = vec![test_deal_offer(&game, None)];
+        game.week = 501;
+        game.check_and_generate_deal_offers();
+        assert_eq!(game.pending_deal_offers.len(), 1, "legacy offers must never expire");
+
+        // And the on-disk shape old builds wrote — no expires_week key at
+        // all — must deserialize to exactly that.
+        let mut on_disk = serde_json::to_value(test_deal_offer(&game, Some(9))).unwrap();
+        on_disk.as_object_mut().unwrap().remove("expires_week");
+        let loaded: PotentialDealOffer = serde_json::from_value(on_disk).unwrap();
+        assert_eq!(loaded.expires_week, None);
     }
 }

--- a/src/game/world.rs
+++ b/src/game/world.rs
@@ -12,6 +12,12 @@ pub struct PotentialDealOffer {
     pub royalty_rate: f32,
     pub albums_required: u8,
     pub original_label_data: RecordLabel,
+    /// The week the label withdraws the offer if it's ignored. `None`
+    /// means it never expires — deliberately, because offers saved before
+    /// expiry existed deserialize to `None`, and a bare numeric default
+    /// (0) would kill every live offer the moment an old save loaded.
+    #[serde(default)]
+    pub expires_week: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -726,6 +732,9 @@ impl GameWorld {
                             royalty_rate,
                             albums_required,
                             original_label_data: label.clone(),
+                            // The world has no clock; the game stamps the
+                            // deadline when the offer lands on the table.
+                            expires_week: None,
                         });
                     }
                 }

--- a/src/game/world.rs
+++ b/src/game/world.rs
@@ -170,6 +170,14 @@ pub const CHART_SIZE: usize = 10;
 const CHART_DECAY: f32 = 0.85;
 const CHART_FLOOR_SCORE: u32 = 25;
 
+// Deal-offer buzz: the scale the tier thresholds in record_labels.json
+// measure (independent 10, boutique 20, major 30). Fame carries most of it;
+// records prove you can deliver; a charting record adds short-lived heat.
+const BUZZ_PER_SINGLE: u32 = 3;
+const BUZZ_PER_ALBUM: u32 = 4;
+const BUZZ_CATALOG_CAP: u32 = 10;
+const BUZZ_CHART_BONUS: u32 = 2;
+
 impl GameWorld {
     pub fn new(data_files: &GameDataFiles, rng: &mut impl Rng) -> Self {
         Self {
@@ -621,6 +629,33 @@ impl GameWorld {
         demand_mod * saturation_penalty * economic_mod
     }
 
+    /// Industry buzz: how loudly the trade papers talk about an act. This is
+    /// the scale the label tier thresholds in record_labels.json measure
+    /// (independent 10, boutique 20, major 30).
+    ///
+    /// Intent: tiers unlock along a real career arc, not on fame alone.
+    /// Fame is the backbone (3 buzz per 10 fame), the catalog widens each
+    /// window (a single is 3, an album 4 — proof you deliver records), and
+    /// a record on this week's chart adds a little heat while it lasts.
+    /// The catalog contribution is capped so a deep back-catalog can pull
+    /// an act one tier up, but never substitutes for genuine stardom.
+    /// Where that lands, with the JSON thresholds also applying:
+    /// independents around fame ~25 with a first record out, boutiques in
+    /// the ~45-60 mid-career, majors only for genuinely big acts (fame
+    /// ~65+ cold, ~60 while a record is charting).
+    fn band_buzz(&self, band: &Band) -> u8 {
+        let fame_heat = u32::from(band.fame) * 3 / 10;
+        let catalog_heat = (band.singles_released.len() as u32 * BUZZ_PER_SINGLE
+            + band.albums_released.len() as u32 * BUZZ_PER_ALBUM)
+            .min(BUZZ_CATALOG_CAP);
+        let chart_heat = if self.charts.iter().any(|entry| entry.is_player) {
+            BUZZ_CHART_BONUS
+        } else {
+            0
+        };
+        (fame_heat + catalog_heat + chart_heat).min(100) as u8
+    }
+
     pub fn generate_deal_offers(
         &self,
         band: &Band,
@@ -629,6 +664,7 @@ impl GameWorld {
     ) -> Vec<PotentialDealOffer> {
         let mut offers = Vec::new();
         let labels_data = game_data.get_record_labels_data();
+        let buzz = self.band_buzz(band);
 
         let label_tiers = [
             ("Major", &labels_data.major_labels, &labels_data.label_requirements.major_label_interest_threshold),
@@ -638,14 +674,14 @@ impl GameWorld {
 
         for (tier_name, labels_in_tier, threshold) in &label_tiers {
             for label in *labels_in_tier {
-                // Check if band meets threshold
-                // Placeholder for buzz: use band.fame / 10 for now, or a fixed value like 50
-                let buzz_placeholder = band.fame / 5; // Example placeholder
-
+                // The `singles` column reads as "records out, of any kind":
+                // an album on the shelf opens doors at least as well as a
+                // 45, so an act that went straight to albums isn't
+                // invisible to every A&R desk in town.
                 if band.fame >= threshold.fame &&
                    band.albums_released.len() >= threshold.albums as usize &&
-                   band.singles_released.len() >= threshold.singles as usize &&
-                   buzz_placeholder >= threshold.buzz {
+                   band.total_releases() >= threshold.singles as usize &&
+                   buzz >= threshold.buzz {
 
                     // Check if already signed with this label
                     if let Some(current_deal) = band.current_deal()
@@ -827,5 +863,148 @@ mod tests {
         assert_eq!(poached.as_deref(), Some(biggest.as_str()));
         let signed = world.bands.iter().find(|b| b.name == biggest).unwrap();
         assert_eq!(signed.label.as_deref(), Some("Apex Records"));
+    }
+
+    // --- Deal scouting: label tiers unlock along a real career arc ---
+
+    use crate::game::music::{Release, ReleaseType};
+
+    fn record(release_type: ReleaseType) -> Release {
+        Release {
+            id: 0,
+            name: "Test Record".to_string(),
+            release_type,
+            release_quality: 50,
+            week_released: 0,
+            songs_involved_quality_avg: 50,
+            active_marketing: Vec::new(),
+            marketing_level_achieved: 0,
+            initial_sales_score: 0,
+            total_income_generated: 0,
+            genre: None,
+            copies_pressed: 0,
+            copies_sold: 0,
+        }
+    }
+
+    /// A player band with the given fame and catalog.
+    fn act(fame: u8, singles: usize, albums: usize) -> Band {
+        Band {
+            fame,
+            singles_released: (0..singles).map(|_| record(ReleaseType::Single)).collect(),
+            albums_released: (0..albums).map(|_| record(ReleaseType::Album)).collect(),
+            ..Band::default()
+        }
+    }
+
+    /// Which tiers ever bite across plenty of offer rolls. The threshold
+    /// gates are deterministic — only the per-label coin flip is random —
+    /// so enough rolls make an unlocked tier impossible to miss, while a
+    /// locked tier stays silent on every single roll.
+    fn tiers_scouting(
+        world: &GameWorld,
+        data: &GameDataFiles,
+        band: &Band,
+    ) -> std::collections::HashSet<String> {
+        let mut rng = StdRng::seed_from_u64(77);
+        let mut tiers = std::collections::HashSet::new();
+        for _ in 0..40 {
+            for offer in world.generate_deal_offers(band, data, &mut rng) {
+                tiers.insert(offer.label_tier);
+            }
+        }
+        tiers
+    }
+
+    #[test]
+    fn independent_labels_scout_a_working_act_early() {
+        let data = GameDataFiles::load().expect("data files present");
+        let world = GameWorld::new(&data, &mut StdRng::seed_from_u64(31));
+
+        // Local fame and a first single out: indies bite, nobody bigger.
+        let tiers = tiers_scouting(&world, &data, &act(25, 1, 0));
+        assert!(
+            tiers.contains("Independent"),
+            "a fame-25 act with a single out should draw indie interest, got {tiers:?}"
+        );
+        assert!(!tiers.contains("Boutique"), "boutiques should wait for the mid-career");
+        assert!(!tiers.contains("Major"), "majors do not scout the small clubs");
+
+        // The same noise with nothing on the shelves draws nobody at all.
+        let all_talk = tiers_scouting(&world, &data, &act(30, 0, 0));
+        assert!(all_talk.is_empty(), "no catalog, no offers, got {all_talk:?}");
+
+        // An act that went straight to an album is a record out all the
+        // same — not invisible for lacking a 45.
+        let album_first = tiers_scouting(&world, &data, &act(25, 0, 1));
+        assert!(
+            album_first.contains("Independent"),
+            "an album counts as a record out, got {album_first:?}"
+        );
+    }
+
+    #[test]
+    fn boutique_labels_court_the_mid_career_act() {
+        let data = GameDataFiles::load().expect("data files present");
+        let world = GameWorld::new(&data, &mut StdRng::seed_from_u64(31));
+
+        let tiers = tiers_scouting(&world, &data, &act(50, 2, 1));
+        assert!(
+            tiers.contains("Boutique"),
+            "a fame-50 act with a small catalog should draw boutique interest, got {tiers:?}"
+        );
+        assert!(!tiers.contains("Major"), "majors should still be out of reach at fame 50");
+    }
+
+    #[test]
+    fn major_labels_only_sign_genuinely_big_acts() {
+        let data = GameDataFiles::load().expect("data files present");
+        let world = GameWorld::new(&data, &mut StdRng::seed_from_u64(31));
+
+        // An album and three singles out, but fame 60: the majors keep watching.
+        let almost = tiers_scouting(&world, &data, &act(60, 3, 1));
+        assert!(
+            !almost.contains("Major"),
+            "fame 60 should not yet be enough for the majors, got {almost:?}"
+        );
+        assert!(almost.contains("Boutique"), "the mid tiers should be all over them though");
+
+        // Ten more points of fame and the phone rings. (Under the old
+        // placeholder — buzz = fame/5 against a threshold of 30 — no major
+        // could call even at fame 100.)
+        let star = tiers_scouting(&world, &data, &act(70, 3, 1));
+        assert!(
+            star.contains("Major"),
+            "a fame-70 act with a real catalog should finally draw a major, got {star:?}"
+        );
+
+        // But no album, no major — singles alone don't prove you can
+        // deliver the LPs a major contract is made of.
+        let no_album = tiers_scouting(&world, &data, &act(70, 4, 0));
+        assert!(
+            !no_album.contains("Major"),
+            "majors require an album in the catalog, got {no_album:?}"
+        );
+    }
+
+    #[test]
+    fn buzz_weighs_the_catalog_and_a_charting_record() {
+        let data = GameDataFiles::load().expect("data files present");
+        let mut world = GameWorld::new(&data, &mut StdRng::seed_from_u64(31));
+
+        // Same fame, deeper catalog: more buzz...
+        assert!(world.band_buzz(&act(50, 2, 1)) > world.band_buzz(&act(50, 0, 0)));
+        // ...but a shelf of records alone never adds up to stardom.
+        assert_eq!(
+            world.band_buzz(&act(0, 10, 10)),
+            BUZZ_CATALOG_CAP as u8,
+            "the catalog contribution is capped"
+        );
+
+        // A record on this week's chart adds heat while it lasts.
+        let star = act(60, 3, 1);
+        let cold = world.band_buzz(&star);
+        world.submit_chart_entry("The Hit".into(), "The Test Pattern".into(), true, 5_000);
+        assert_eq!(world.band_buzz(&star), cold + BUZZ_CHART_BONUS as u8);
     }
 }

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -414,11 +414,21 @@ fn draw_deals_modal(frame: &mut Frame, app: &App) {
         frame.render_widget(block, area);
 
         let data = &offer.original_label_data;
-        let lines = vec![
+        let mut lines = vec![
             Line::from(""),
             Line::from(format!("  Advance          {}", format_money(offer.advance as i32))),
             Line::from(format!("  Royalty rate     {:.1}%", offer.royalty_rate * 100.0)),
             Line::from(format!("  Albums required  {}", offer.albums_required)),
+        ];
+        if let Some(deadline) = offer.expires_week {
+            let weeks_left = deadline.saturating_sub(app.game.week);
+            lines.push(Line::from(format!(
+                "  Offer expires in {} week{}",
+                weeks_left,
+                if weeks_left == 1 { "" } else { "s" }
+            )));
+        }
+        lines.extend([
             Line::from(""),
             Line::styled("  About the label", Style::new().fg(Color::Cyan).bold()),
             Line::from(format!("  Market reach       {}/100", data.market_reach)),
@@ -428,7 +438,7 @@ fn draw_deals_modal(frame: &mut Frame, app: &App) {
             Line::from(format!("  Reputation: {}", data.reputation)),
             Line::from(""),
             Line::styled("  [A]ccept · [R]eject · [Esc] back", Style::new().fg(Color::DarkGray)),
-        ];
+        ]);
         frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
     } else {
         let items: Vec<ListItem> = offers


### PR DESCRIPTION
HANDOFF.md Track F. **Merge order: before Track B** (B is in flight and will rebase over this).

**Scouting rework** — replaces the `buzz = fame/5` placeholder that made major-label offers mathematically impossible (fame 150 needed). New gate: `buzz = fame×3/10 + min(3·singles + 4·albums, 10) + 2 while charting`, against the unchanged record_labels.json thresholds. Career arc now: indies scout you at fame ~20–25 with a record out, boutiques mid-career (~45–60), majors at ~60–70 (a charting record buys transient heat). The catalog widens each window but is capped — it can't substitute for stardom.

**Offer expiry** — offers now live 4 weeks (stamped in mod.rs; world.rs stays clock-free), leave with an in-fiction "interest has cooled" line, and no longer block the stream. Expiry is NOT rejection: poaching remains a consequence of explicitly rejecting a deal (test-guarded). Serde trap handled: `expires_week: Option<u32>` so offers in old saves load as never-expiring (test strips the field from JSON and asserts it).

**One deliberate reinterpretation:** the data's `singles` threshold now counts releases of any kind (`total_releases()`) — album-first careers were otherwise invisible to labels, which alone explained 25/60 sim careers never signing. Majors still require an actual album. Data file untouched.

**Sim evidence** (Track D harness, 60 seeds × 15y, label-loyalist): first deal median week 144 → **36**; careers that ever sign 35/60 → **60/60**; win rate 76% → 85%; median money $82k → $667k (major advances now exist).

Verification: 40 tests pass (6 new, incl. per-tier reachability and expiry/no-poach), both ignored sweeps green, clippy zero warnings. Coordinator independently re-verified in an isolated build. Also shows "Offer expires in N weeks" in the deals modal (14 lines in render.rs beyond the nominal track surface — copies the support-modal pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)