### PR TITLE
Track B: fully deterministic gameplay under ROCKER_SEED

### DIFF
--- a/src/data_loader.rs
+++ b/src/data_loader.rs
@@ -284,32 +284,28 @@ impl GameDataFiles {
         Ok(serde_json::from_str(&content)?)
     }
 
-    pub fn random_song_title(&self) -> String {
-        self.generate_song_title(&mut thread_rng())
-    }
-
-    pub fn random_album_title(&self) -> String {
-        let mut rng = thread_rng();
-
+    /// An album title from the caller's RNG: sometimes a curated title,
+    /// usually a composed song title promoted to the cover.
+    pub fn random_album_title(&self, rng: &mut impl Rng) -> String {
         if rng.gen_bool(0.3) {
             self.album_titles[rng.gen_range(0..self.album_titles.len())].clone()
         } else {
-            self.random_song_title()
+            self.generate_song_title(rng)
         }
     }
 
-    pub fn random_band_name(&self) -> String {
-        let mut rng = thread_rng();
+    pub fn random_band_name(&self, rng: &mut impl Rng) -> String {
         self.band_names[rng.gen_range(0..self.band_names.len())].clone()
     }
 
     /// Compose a band name from the pattern grammar. The curated list is one
     /// pattern among several, so the scene can hold hundreds of distinct acts.
     pub fn generate_band_name(&self, rng: &mut impl Rng) -> String {
-        self.band_name_grammar
+        let composed = self
+            .band_name_grammar
             .as_ref()
-            .and_then(|grammar| grammar.flatten(rng).ok())
-            .unwrap_or_else(|| self.random_band_name())
+            .and_then(|grammar| grammar.flatten(rng).ok());
+        composed.unwrap_or_else(|| self.random_band_name(rng))
     }
 
     /// Compose a song title from the pattern grammar, using the caller's RNG.
@@ -351,8 +347,7 @@ impl GameDataFiles {
             .unwrap_or(OUT_OF_FASHION)
     }
 
-    pub fn random_band_member_name(&self) -> String {
-        let mut rng = thread_rng();
+    pub fn random_band_member_name(&self, rng: &mut impl Rng) -> String {
         self.band_member_names[rng.gen_range(0..self.band_member_names.len())].clone()
     }
 

--- a/src/game/events.rs
+++ b/src/game/events.rs
@@ -1,4 +1,4 @@
-use rand::{thread_rng, Rng};
+use rand::Rng;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -26,17 +26,19 @@ impl EventManager {
         current_week - self.last_event_week >= 2
     }
 
-    pub fn try_trigger_event(&mut self, current_week: u32) -> Option<RandomEvent> {
+    pub fn try_trigger_event(
+        &mut self,
+        current_week: u32,
+        rng: &mut impl Rng,
+    ) -> Option<RandomEvent> {
         if !self.should_process_events(current_week) {
             return None;
         }
 
-        let mut rng = thread_rng();
-
         // 30% chance of a random event each eligible week
         if rng.gen_range(0..100) < 30 {
             self.last_event_week = current_week;
-            Some(self.generate_random_event(&mut rng))
+            Some(self.generate_random_event(rng))
         } else {
             None
         }

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -65,6 +65,12 @@ const SUPPORT_OFFER_MIN_FAME: u8 = 5;
 const SUPPORT_OFFER_FAME_GAP: u8 = 10;
 const SUPPORT_OFFER_CHANCE: f64 = 0.06;
 const SUPPORT_OFFER_LIFETIME_WEEKS: u32 = 3;
+
+// Record deals stay on the table about a month — one scouting cycle — so
+// a slate the player sits on clears just as labels next come looking, and
+// ignoring an offer can never silence the deal stream for good.
+const DEAL_OFFER_LIFETIME_WEEKS: u32 = 4;
+
 const PLAYER_MARKET_IMPACT_THRESHOLD_SALES_SCORE: u32 = 600;
 const PLAYER_MARKET_IMPACT_GENRE_MOD_BONUS: f32 = 0.05;
 const PLAYER_MARKET_IMPACT_DEMAND_BONUS: u8 = 1;
@@ -1247,10 +1253,35 @@ impl Game {
         Ok(())
     }
 
+    /// Quietly withdraw deal offers the player sat past their deadline.
+    /// Losing interest is not a rejection: nobody poaches the vacated deal
+    /// (that stays a consequence of `action_reject_deal` alone), and the
+    /// cleared slate lets labels come knocking again. Offers from saves
+    /// that predate expiry (`expires_week: None`) stay on the table
+    /// forever, exactly as they always did.
+    fn expire_stale_deal_offers(&mut self) {
+        let week = self.week;
+        let offers = std::mem::take(&mut self.pending_deal_offers);
+        let (expired, live): (Vec<_>, Vec<_>) = offers
+            .into_iter()
+            .partition(|offer| offer.expires_week.is_some_and(|deadline| week >= deadline));
+        self.pending_deal_offers = live;
+        for offer in expired {
+            self.log(format!(
+                "📪 {}'s interest has cooled — their offer is off the table.",
+                offer.label_name
+            ));
+        }
+    }
+
     fn check_and_generate_deal_offers(&mut self) {
+        self.expire_stale_deal_offers();
         if self.pending_deal_offers.is_empty() && self.week.is_multiple_of(4) && self.band.record_deal.is_none() {
             let mut rng = rand::thread_rng();
-            let new_offers = self.world.generate_deal_offers(&self.band, &self.data_files, &mut rng);
+            let mut new_offers = self.world.generate_deal_offers(&self.band, &self.data_files, &mut rng);
+            for offer in &mut new_offers {
+                offer.expires_week = Some(self.week + DEAL_OFFER_LIFETIME_WEEKS);
+            }
             if !new_offers.is_empty() {
                 let n = new_offers.len();
                 self.pending_deal_offers = new_offers;
@@ -2078,5 +2109,82 @@ mod tests {
             game.turn_log.iter().any(|m| m.contains("went to another band")),
             "expiry should be reported"
         );
+    }
+
+    /// A pending offer as `check_and_generate_deal_offers` would leave it.
+    fn test_deal_offer(game: &Game, expires_week: Option<u32>) -> PotentialDealOffer {
+        let label = game.data_files.get_record_labels_data().independent_labels[0].clone();
+        PotentialDealOffer {
+            label_name: label.name.clone(),
+            label_tier: "Independent".to_string(),
+            advance: 1_000,
+            royalty_rate: 0.12,
+            albums_required: 1,
+            original_label_data: label,
+            expires_week,
+        }
+    }
+
+    #[test]
+    fn ignored_deal_offers_expire_and_the_stream_resumes() {
+        let mut game = test_game();
+        game.pending_deal_offers = vec![test_deal_offer(&game, Some(8))];
+        let unsigned_before = game.world.bands.iter().filter(|b| b.label.is_none()).count();
+
+        // Before the deadline the offer stays on the table.
+        game.week = 7;
+        game.check_and_generate_deal_offers();
+        assert_eq!(game.pending_deal_offers.len(), 1, "a live offer survives to its deadline");
+
+        // At the deadline it quietly leaves — with a line in the log...
+        game.week = 8;
+        game.check_and_generate_deal_offers();
+        assert!(game.pending_deal_offers.is_empty(), "an ignored offer should expire");
+        let log = game.take_turn_log().join("\n");
+        assert!(log.contains("interest has cooled"), "expiry is told in-fiction, got: {log}");
+        // ...and, unlike a rejection, nobody poaches the vacated deal.
+        let unsigned_after = game.world.bands.iter().filter(|b| b.label.is_none()).count();
+        assert_eq!(
+            unsigned_before, unsigned_after,
+            "expiry must not hand the deal to a scene act"
+        );
+
+        // With the slate clear and a catalog worth scouting, the stream
+        // resumes on the next 4-week beat instead of staying silent forever.
+        game.band.fame = 30;
+        game.band.singles_released.push(test_release(1, ReleaseType::Single));
+        let mut resumed = false;
+        for _ in 0..80 {
+            game.check_and_generate_deal_offers();
+            if !game.pending_deal_offers.is_empty() {
+                resumed = true;
+                break;
+            }
+        }
+        assert!(resumed, "new offers should arrive once the slate is clear");
+        assert!(
+            game.pending_deal_offers
+                .iter()
+                .all(|offer| offer.expires_week == Some(game.week + DEAL_OFFER_LIFETIME_WEEKS)),
+            "fresh offers should carry a deadline"
+        );
+    }
+
+    #[test]
+    fn deal_offers_from_old_saves_never_expire() {
+        // Offers already pending when an old save was written carry no
+        // deadline; they stay on the table however late it gets.
+        let mut game = test_game();
+        game.pending_deal_offers = vec![test_deal_offer(&game, None)];
+        game.week = 501;
+        game.check_and_generate_deal_offers();
+        assert_eq!(game.pending_deal_offers.len(), 1, "legacy offers must never expire");
+
+        // And the on-disk shape old builds wrote — no expires_week key at
+        // all — must deserialize to exactly that.
+        let mut on_disk = serde_json::to_value(test_deal_offer(&game, Some(9))).unwrap();
+        on_disk.as_object_mut().unwrap().remove("expires_week");
+        let loaded: PotentialDealOffer = serde_json::from_value(on_disk).unwrap();
+        assert_eq!(loaded.expires_week, None);
     }
 }

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -2241,4 +2241,65 @@ mod tests {
         let loaded: PotentialDealOffer = serde_json::from_value(on_disk).unwrap();
         assert_eq!(loaded.expires_week, None);
     }
+
+    /// Track B's contract: a run is fully determined by its seed and the
+    /// player's choices. Two games on the same seed, fed the same twenty
+    /// turns, must land on the same week with the same money and fame and an
+    /// identical week-by-week story; a different seed must tell a different
+    /// one.
+    #[test]
+    fn same_seed_and_same_choices_replay_the_same_career() {
+        fn scripted_run(seed: u64) -> (u32, i32, u8, String) {
+            let mut game = super::sim::seeded_game(seed);
+            // A representative career slice: writing, gigging, idling, one
+            // club-run single, and a multi-week break (so the per-week RNG
+            // keying survives calendar jumps).
+            let script = [
+                GameAction::WriteSongs,
+                GameAction::Gig(0),
+                GameAction::LazeAround,
+                GameAction::WriteSongs,
+                GameAction::LazeAround,
+                GameAction::RecordSingle { pressing: Some(1) },
+                GameAction::Gig(0),
+                GameAction::LazeAround,
+                GameAction::Gig(0),
+                GameAction::TakeBreak,
+                GameAction::WriteSongs,
+                GameAction::WriteSongs,
+                GameAction::Gig(0),
+                GameAction::LazeAround,
+                GameAction::WriteSongs,
+                GameAction::LazeAround,
+                GameAction::Gig(0),
+                GameAction::LazeAround,
+                GameAction::Gig(0),
+                GameAction::LazeAround,
+            ];
+            let mut log: Vec<String> = Vec::new();
+            for action in script {
+                // A rejection is part of the story too — it must replay.
+                if let Err(rejection) = game.process_turn(action) {
+                    log.push(format!("[rejected] {rejection}"));
+                }
+                log.append(&mut game.take_turn_log());
+            }
+            (game.week, game.player.money, game.band.fame, log.join("\n"))
+        }
+
+        let (week_a, money_a, fame_a, story_a) = scripted_run(2025);
+        let (week_b, money_b, fame_b, story_b) = scripted_run(2025);
+        assert_eq!(week_a, week_b, "same seed, same calendar");
+        assert_eq!(money_a, money_b, "same seed, same bank balance");
+        assert_eq!(fame_a, fame_b, "same seed, same fame");
+        assert_eq!(story_a, story_b, "same seed, same story, line for line");
+
+        // The script must have exercised the seeded rolls for the proof to
+        // mean anything: songs written and a single actually recorded.
+        assert!(story_a.contains("🎼 Wrote"), "the script should write songs:\n{story_a}");
+        assert!(story_a.contains("🎙️ Recorded"), "the script should record a single:\n{story_a}");
+
+        let (_, _, _, story_c) = scripted_run(2026);
+        assert_ne!(story_a, story_c, "a different seed must tell a different story");
+    }
 }

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -95,6 +95,17 @@ pub const BREAK_WEEKS: u32 = 4;
 const GENRE_TREND_HOT: f32 = 1.15;
 const GENRE_TREND_COLD: f32 = 0.85;
 
+// Determinism: everything after seed selection derives from world_seed, so a
+// seed replays a whole career. Two independent streams share the splitmix64
+// key derivation (see `advance_week_events` for the world stream): the world
+// stream evolves the scene, the action stream feeds every roll the player's
+// own actions make. Salting the action keys keeps the streams uncorrelated —
+// your tour luck never mirrors next week's scene news.
+const ACTION_STREAM_SALT: u64 = 0x243F_6A88_85A3_08D3; // π's fraction bits: arbitrary, fixed forever
+// Setup rolls (bandmate names) draw from a reserved pre-game week, so they
+// can never replay week 1's action stream.
+const SETUP_STREAM_WEEK: u64 = 0;
+
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum GameAction {
@@ -126,6 +137,8 @@ pub struct SupportTourOffer {
     pub expires_week: u32,
 }
 
+/// The one deliberate use of ambient entropy: choosing a world seed when
+/// ROCKER_SEED doesn't dictate one. Every roll after this derives from it.
 fn default_seed() -> u64 {
     rand::random::<u64>()
 }
@@ -209,29 +222,56 @@ impl Game {
         std::mem::take(&mut self.turn_log)
     }
 
+    /// The action-stream RNG for a given week: the same splitmix64 key
+    /// derivation the world stream uses in `advance_week_events`, applied to
+    /// the salted seed (see `ACTION_STREAM_SALT`). Derived on demand, never
+    /// stored — saves carry no RNG state, and a loaded game rolls exactly
+    /// what the unsaved one would have.
+    fn action_rng_for_week(&self, week: u64) -> StdRng {
+        let mut key = (self.world_seed ^ ACTION_STREAM_SALT)
+            .wrapping_add(week)
+            .wrapping_mul(0x9E3779B97F4A7C15);
+        key = (key ^ (key >> 30)).wrapping_mul(0xBF58476D1CE4E5B8);
+        key = (key ^ (key >> 27)).wrapping_mul(0x94D049BB133111EB);
+        key ^= key >> 31;
+        StdRng::seed_from_u64(key)
+    }
+
+    /// Every roll made while resolving the current turn draws from this one
+    /// stream, in order: the action itself, then the week's random event,
+    /// then offer generation. Turn-consuming actions move the calendar, so
+    /// consecutive turns get fresh streams; the rare same-week paperwork
+    /// action (rejecting two deals in one sitting) rereads the week's stream,
+    /// which is deterministic and harmless.
+    fn action_rng(&self) -> StdRng {
+        self.action_rng_for_week(self.week as u64)
+    }
+
     pub fn initialize_player(&mut self, player_name: &str, band_name: &str, genre: world::MusicGenre) {
         self.player.name = player_name.to_string();
         self.band.name = band_name.to_string();
         self.band.genre = genre;
         self.player.money = 500; // Starting cash in 1970
 
+        // Bandmates are part of the seed's identity, like the scene itself.
+        let mut rng = self.action_rng_for_week(SETUP_STREAM_WEEK);
         self.band.members = vec![
             band::BandMember {
-                name: self.data_files.random_band_member_name(),
+                name: self.data_files.random_band_member_name(&mut rng),
                 instrument: band::Instrument::Guitar,
                 skill: 25,
                 loyalty: 75,
                 drug_problem: false,
             },
             band::BandMember {
-                name: self.data_files.random_band_member_name(),
+                name: self.data_files.random_band_member_name(&mut rng),
                 instrument: band::Instrument::Bass,
                 skill: 20,
                 loyalty: 80,
                 drug_problem: false,
             },
             band::BandMember {
-                name: self.data_files.random_band_member_name(),
+                name: self.data_files.random_band_member_name(&mut rng),
                 instrument: band::Instrument::Drums,
                 skill: 30,
                 loyalty: 70,
@@ -241,7 +281,7 @@ impl Game {
     }
 
     // --- Song and Release Calculation Helper Methods (Step 4) ---
-    fn calculate_songwriting_quality(&self) -> u8 {
+    fn calculate_songwriting_quality(&self, rng: &mut impl Rng) -> u8 {
         let mut quality = QUALITY_BASE_SONGWRITING as f32;
         let mut player_bonus = 0.0;
 
@@ -259,7 +299,6 @@ impl Game {
         quality += player_bonus.min(QUALITY_SONGWRITING_MAX_BONUS_PLAYER_STATS as f32);
 
         // Random variation
-        let mut rng = rand::thread_rng();
         let random_offset = rng.gen_range(0..=QUALITY_SONGWRITING_RANDOM_VARIATION) as i8 - (QUALITY_SONGWRITING_RANDOM_VARIATION / 2) as i8;
         quality += random_offset as f32;
         
@@ -286,7 +325,7 @@ impl Game {
         Ok((selected_songs, avg_quality))
     }
 
-    fn calculate_release_quality(&self, avg_song_quality: u8) -> u8 {
+    fn calculate_release_quality(&self, avg_song_quality: u8, rng: &mut impl Rng) -> u8 {
         let mut quality = (QUALITY_BASE_RECORDING as f32 + avg_song_quality as f32) / 2.0; 
         
         quality += (self.band.skill / 10) as f32;
@@ -298,7 +337,6 @@ impl Game {
         else if self.player.stress < 60 { player_bonus += 1.0; }
         quality += player_bonus.min(QUALITY_RECORDING_MAX_BONUS_PLAYER_STATS as f32);
 
-        let mut rng = rand::thread_rng();
         let random_offset = rng.gen_range(0..=QUALITY_RECORDING_RANDOM_VARIATION) as i8 - (QUALITY_RECORDING_RANDOM_VARIATION / 2) as i8;
         quality += random_offset as f32;
         
@@ -416,17 +454,17 @@ impl Game {
         Ok(())
     }
 
-    fn action_write_songs(&mut self) -> Result<(), String> {
+    fn action_write_songs(&mut self, rng: &mut impl Rng) -> Result<(), String> {
         if self.player.energy < 20 {
             return Err("You're too tired to write songs!".to_string());
         }
         self.player.energy -= 20;
 
-        let num_songs_to_write = rand::thread_rng().gen_range(1..=3);
+        let num_songs_to_write = rng.gen_range(1..=3);
         let mut titles = Vec::new();
         for _ in 0..num_songs_to_write {
-            let quality = self.calculate_songwriting_quality();
-            let song_name = self.data_files.random_song_title();
+            let quality = self.calculate_songwriting_quality(rng);
+            let song_name = self.data_files.generate_song_title(rng);
             titles.push(format!("\"{}\"", song_name));
             self.band.unreleased_songs.push(music::Song {
                 id: self.next_song_id,
@@ -455,7 +493,11 @@ impl Game {
         Ok(())
     }
 
-    fn action_record_single(&mut self, pressing: Option<usize>) -> Result<(), String> {
+    fn action_record_single(
+        &mut self,
+        pressing: Option<usize>,
+        rng: &mut impl Rng,
+    ) -> Result<(), String> {
         if !self.band.can_record_single() {
              return Err("You need to write at least one song first!".to_string());
         }
@@ -479,7 +521,7 @@ impl Game {
         }
         self.player.spend_money(cost);
 
-        let release_quality = self.calculate_release_quality(avg_song_quality);
+        let release_quality = self.calculate_release_quality(avg_song_quality, rng);
         let release_name = format!("Single: {}", selected_songs[0].name);
 
         let new_release = music::Release {
@@ -515,7 +557,11 @@ impl Game {
         Ok(())
     }
 
-    fn action_record_album(&mut self, pressing: Option<usize>) -> Result<(), String> {
+    fn action_record_album(
+        &mut self,
+        pressing: Option<usize>,
+        rng: &mut impl Rng,
+    ) -> Result<(), String> {
         if !self.band.can_record_album() {
             return Err(format!("You need at least {} unreleased songs to record an album!", constants::MIN_ALBUM_SONGS));
         }
@@ -539,8 +585,8 @@ impl Game {
         }
         self.player.spend_money(cost);
 
-        let release_quality = self.calculate_release_quality(avg_song_quality);
-        let release_name = self.data_files.random_album_title();
+        let release_quality = self.calculate_release_quality(avg_song_quality, rng);
+        let release_name = self.data_files.random_album_title(rng);
 
         let new_release = music::Release {
             id: self.next_release_id,
@@ -738,7 +784,7 @@ impl Game {
         Ok(())
     }
 
-    fn action_go_on_tour(&mut self, region_index: usize) -> Result<(), String> {
+    fn action_go_on_tour(&mut self, region_index: usize, rng: &mut impl Rng) -> Result<(), String> {
         if self.player.energy < 40 {
             return Err("You're too tired to go on tour!".to_string());
         }
@@ -809,8 +855,7 @@ impl Game {
         // Tours are live shows too: fame stalls at the catalog cap.
         let fame_gain = fame_gain.min(self.live_fame_cap().saturating_sub(self.band.fame));
         self.band.fame += fame_gain;
-        
-        let mut rng = rand::thread_rng();
+
         let regional_fame_gain = 10 + rng.gen_range(0..=5);
         let new_regional_fame = (regional_fame as u16 + regional_fame_gain as u16).min(100) as u8;
         self.regional_fame.insert(regional_fame_key.clone(), new_regional_fame);
@@ -914,21 +959,20 @@ impl Game {
         Ok(())
     }
 
-    fn action_reject_deal(&mut self, offer_index: usize) -> Result<(), String> {
+    fn action_reject_deal(&mut self, offer_index: usize, rng: &mut impl Rng) -> Result<(), String> {
         if offer_index >= self.pending_deal_offers.len() {
             return Err("Invalid deal offer selected.".to_string());
         }
         let offer = self.pending_deal_offers.remove(offer_index);
         self.log(format!("🚫 Turned down {}'s offer.", offer.label_name));
-        
-        let mut rng = rand::thread_rng();
-        if let Some(poaching_band) = self.world.poach_rejected_deal(&offer.label_name, &mut rng) {
+
+        if let Some(poaching_band) = self.world.poach_rejected_deal(&offer.label_name, rng) {
             self.log(format!("📰 NEWS: {} signed with {} after you turned them down!", poaching_band, offer.label_name));
         }
         Ok(())
     }
 
-    fn action_accept_support_tour(&mut self) -> Result<(), String> {
+    fn action_accept_support_tour(&mut self, rng: &mut impl Rng) -> Result<(), String> {
         let Some(offer) = self.pending_support_offer.clone() else {
             return Err("Nobody has offered you a support slot.".to_string());
         };
@@ -947,7 +991,6 @@ impl Game {
             offer.host_band, offer.weeks, offer.pay, offer.fame_gain
         ));
 
-        let mut rng = rand::thread_rng();
         if rng.gen_bool(0.25) {
             self.band.fame = (self.band.fame + 2).min(constants::MAX_FAME);
             self.log("🔥 Their crowd adopted you — encores every night (+2 fame).");
@@ -965,7 +1008,7 @@ impl Game {
 
     /// Expire a stale support offer, or roll for a new one from a bigger
     /// scene act famous enough to headline over you.
-    fn update_support_tour_offer(&mut self) {
+    fn update_support_tour_offer(&mut self, rng: &mut impl Rng) {
         if let Some(offer) = &self.pending_support_offer {
             if self.week >= offer.expires_week {
                 let host = offer.host_band.clone();
@@ -981,7 +1024,6 @@ impl Game {
         if self.band.fame < SUPPORT_OFFER_MIN_FAME {
             return;
         }
-        let mut rng = rand::thread_rng();
         if !rng.gen_bool(SUPPORT_OFFER_CHANCE) {
             return;
         }
@@ -1019,20 +1061,20 @@ impl Game {
     }
     
     // --- Main execute_action ---
-    fn execute_action(&mut self, action: GameAction) -> Result<(), String> {
+    fn execute_action(&mut self, action: GameAction, rng: &mut impl Rng) -> Result<(), String> {
         match action {
             GameAction::LazeAround => self.action_laze_around(),
-            GameAction::WriteSongs => self.action_write_songs(),
+            GameAction::WriteSongs => self.action_write_songs(rng),
             GameAction::Practice => self.action_practice(),
-            GameAction::RecordSingle { pressing } => self.action_record_single(pressing),
-            GameAction::RecordAlbum { pressing } => self.action_record_album(pressing),
+            GameAction::RecordSingle { pressing } => self.action_record_single(pressing, rng),
+            GameAction::RecordAlbum { pressing } => self.action_record_album(pressing, rng),
             GameAction::Gig(venue_index) => self.action_play_gig(venue_index),
-            GameAction::GoOnTour(region_index) => self.action_go_on_tour(region_index),
+            GameAction::GoOnTour(region_index) => self.action_go_on_tour(region_index, rng),
             GameAction::TakeBreak => self.action_take_break(),
             GameAction::VisitDoctor => self.action_visit_doctor(),
             GameAction::AcceptDeal(index) => self.action_accept_deal(index),
-            GameAction::RejectDeal(index) => self.action_reject_deal(index),
-            GameAction::AcceptSupportTour => self.action_accept_support_tour(),
+            GameAction::RejectDeal(index) => self.action_reject_deal(index, rng),
+            GameAction::AcceptSupportTour => self.action_accept_support_tour(rng),
             GameAction::DeclineSupportTour => self.action_decline_support_tour(),
             GameAction::StartMarketingCampaign(release_id, campaign_type) => self.action_start_marketing_campaign(release_id, campaign_type),
             GameAction::Quit => {
@@ -1213,7 +1255,7 @@ impl Game {
         }
     }
 
-    fn advance_week_events(&mut self) -> Result<(), String> {
+    fn advance_week_events(&mut self, rng: &mut impl Rng) -> Result<(), String> {
         // Sync the timeline with the current week. Tours can jump several weeks
         // at once, so catch up year by year instead of testing a single boundary.
         let expected_year =
@@ -1226,8 +1268,8 @@ impl Game {
         }
         self.update_genre_trend_news();
 
-        if let Some(event) = self.events.try_trigger_event(self.week) {
-            self.apply_random_event(event)?;
+        if let Some(event) = self.events.try_trigger_event(self.week, rng) {
+            self.apply_random_event(event, rng)?;
         }
 
         self.player.weekly_health_decay();
@@ -1239,8 +1281,12 @@ impl Game {
         key ^= key >> 31;
         let mut wk_rng = StdRng::seed_from_u64(key);
 
+        // The world stream (wk_rng) is drawn in a fixed order — historical
+        // events, then the scene update — so a seed's world evolves the same
+        // regardless of what the player did. The player-facing consequences
+        // of a historical event roll on the action stream instead.
         if let Some(historical_event) = self.timeline.take_historical_event(&mut wk_rng) {
-            self.apply_historical_event(&historical_event)?;
+            self.apply_historical_event(&historical_event, rng)?;
             self.log(format!("📰 MUSIC NEWS: {}", historical_event));
         }
 
@@ -1249,7 +1295,7 @@ impl Game {
             self.log(item);
         }
 
-        self.update_support_tour_offer();
+        self.update_support_tour_offer(rng);
         Ok(())
     }
 
@@ -1274,11 +1320,10 @@ impl Game {
         }
     }
 
-    fn check_and_generate_deal_offers(&mut self) {
+    fn check_and_generate_deal_offers(&mut self, rng: &mut impl Rng) {
         self.expire_stale_deal_offers();
         if self.pending_deal_offers.is_empty() && self.week.is_multiple_of(4) && self.band.record_deal.is_none() {
-            let mut rng = rand::thread_rng();
-            let mut new_offers = self.world.generate_deal_offers(&self.band, &self.data_files, &mut rng);
+            let mut new_offers = self.world.generate_deal_offers(&self.band, &self.data_files, rng);
             for offer in &mut new_offers {
                 offer.expires_week = Some(self.week + DEAL_OFFER_LIFETIME_WEEKS);
             }
@@ -1308,18 +1353,22 @@ impl Game {
                 | GameAction::Quit
         );
 
+        // One stream for the whole turn, keyed by the week the player acted
+        // in. Multi-week actions (tours, breaks) re-key next turn anyway.
+        let mut rng = self.action_rng();
+
         let week_before = self.week;
-        self.execute_action(action.clone())?; // Execute action first
+        self.execute_action(action.clone(), &mut rng)?; // Execute action first
 
         if is_turn_consuming_action {
             self.week += 1; // Advance week only for turn-consuming actions
-            self.advance_week_events()?; // Process standard weekly events
+            self.advance_week_events(&mut rng)?; // Process standard weekly events
             self.update_public_visibility(&action, self.week - week_before);
         }
-        
+
         // These happen after every action resolution, regardless of turn consumption
         self.process_music_releases_and_marketing();
-        self.check_and_generate_deal_offers();
+        self.check_and_generate_deal_offers(&mut rng);
         self.check_game_over();
 
         Ok(!self.game_over)
@@ -1363,9 +1412,12 @@ impl Game {
         }
     }
 
-    fn apply_random_event(&mut self, event: events::RandomEvent) -> Result<(), String> {
+    fn apply_random_event(
+        &mut self,
+        event: events::RandomEvent,
+        rng: &mut impl Rng,
+    ) -> Result<(), String> {
         use events::RandomEvent;
-        let mut rng = rand::thread_rng();
 
         match event {
             RandomEvent::DrugOffer => {
@@ -1544,9 +1596,7 @@ impl Game {
         Ok(())
     }
 
-    fn apply_historical_event(&mut self, event: &str) -> Result<(), String> {
-        let mut rng = rand::thread_rng();
-
+    fn apply_historical_event(&mut self, event: &str, rng: &mut impl Rng) -> Result<(), String> {
         match event {
             event if event.contains("Beatles") => {
                 if self.band.dominant_genres_match(&["Rock", "Folk Rock"]) {
@@ -1939,7 +1989,8 @@ mod tests {
         });
         game.player.money = 0;
 
-        assert!(game.action_record_single(Some(0)).is_err());
+        let mut rng = StdRng::seed_from_u64(0);
+        assert!(game.action_record_single(Some(0), &mut rng).is_err());
         assert_eq!(
             game.band.unreleased_songs.len(),
             1,
@@ -1963,7 +2014,9 @@ mod tests {
         });
         let week_before = game.week;
 
-        game.action_accept_support_tour().expect("offer should be acceptable");
+        let mut rng = StdRng::seed_from_u64(0);
+        game.action_accept_support_tour(&mut rng)
+            .expect("offer should be acceptable");
 
         assert!(game.pending_support_offer.is_none());
         assert_eq!(game.player.money, 1500);
@@ -1997,9 +2050,10 @@ mod tests {
         game.world.bands[0].fame = 80;
 
         let mut offered = false;
+        let mut rng = StdRng::seed_from_u64(1);
         for week in 1..=200 {
             game.week = week;
-            game.update_support_tour_offer();
+            game.update_support_tour_offer(&mut rng);
             if game.pending_support_offer.is_some() {
                 offered = true;
                 break;
@@ -2103,7 +2157,7 @@ mod tests {
         });
         game.week = 5;
 
-        game.update_support_tour_offer();
+        game.update_support_tour_offer(&mut StdRng::seed_from_u64(0));
         assert!(game.pending_support_offer.is_none(), "offers should expire");
         assert!(
             game.turn_log.iter().any(|m| m.contains("went to another band")),
@@ -2133,12 +2187,12 @@ mod tests {
 
         // Before the deadline the offer stays on the table.
         game.week = 7;
-        game.check_and_generate_deal_offers();
+        game.check_and_generate_deal_offers(&mut StdRng::seed_from_u64(0));
         assert_eq!(game.pending_deal_offers.len(), 1, "a live offer survives to its deadline");
 
         // At the deadline it quietly leaves — with a line in the log...
         game.week = 8;
-        game.check_and_generate_deal_offers();
+        game.check_and_generate_deal_offers(&mut StdRng::seed_from_u64(0));
         assert!(game.pending_deal_offers.is_empty(), "an ignored offer should expire");
         let log = game.take_turn_log().join("\n");
         assert!(log.contains("interest has cooled"), "expiry is told in-fiction, got: {log}");
@@ -2154,8 +2208,8 @@ mod tests {
         game.band.fame = 30;
         game.band.singles_released.push(test_release(1, ReleaseType::Single));
         let mut resumed = false;
-        for _ in 0..80 {
-            game.check_and_generate_deal_offers();
+        for attempt in 0..80 {
+            game.check_and_generate_deal_offers(&mut StdRng::seed_from_u64(attempt));
             if !game.pending_deal_offers.is_empty() {
                 resumed = true;
                 break;
@@ -2177,7 +2231,7 @@ mod tests {
         let mut game = test_game();
         game.pending_deal_offers = vec![test_deal_offer(&game, None)];
         game.week = 501;
-        game.check_and_generate_deal_offers();
+        game.check_and_generate_deal_offers(&mut StdRng::seed_from_u64(0));
         assert_eq!(game.pending_deal_offers.len(), 1, "legacy offers must never expire");
 
         // And the on-disk shape old builds wrote — no expires_week key at

--- a/src/game/sim.rs
+++ b/src/game/sim.rs
@@ -52,7 +52,7 @@ const STALL_LIMIT: u32 = 100;
 /// harness assembles the identical state directly instead. Keep this in
 /// lockstep with `Game::new`; `seeded_worlds_are_reproducible_in_the_harness`
 /// guards the determinism property itself.
-fn seeded_game(seed: u64) -> Game {
+pub(super) fn seeded_game(seed: u64) -> Game {
     let data_files = GameDataFiles::load().expect("data files present");
     let mut init_rng = StdRng::seed_from_u64(seed);
     let world = GameWorld::new(&data_files, &mut init_rng);
@@ -573,6 +573,27 @@ fn seeded_worlds_are_reproducible_in_the_harness() {
         band_names(&seeded_game(42)),
         band_names(&seeded_game(43)),
         "different seed, different scene"
+    );
+
+    // Since Track B seeded the action stream too, an entire short career —
+    // not just the opening scene — replays exactly.
+    let career_facts = |seed: u64| {
+        let career = run_career(Bot::BalancedIndie, seed, 2 * constants::WEEKS_PER_YEAR);
+        (
+            career.weeks,
+            career.final_fame,
+            career.peak_fame,
+            career.final_money,
+            career.albums,
+            career.singles,
+            career.sell_outs,
+            career.weeks_to_first_album,
+        )
+    };
+    assert_eq!(
+        career_facts(42),
+        career_facts(42),
+        "same seed, same policy, same career — to the week and the dollar"
     );
 }
 

--- a/src/game/sim.rs
+++ b/src/game/sim.rs
@@ -10,8 +10,10 @@
 //! - `#[ignore]`d sweeps: many seeds over fifteen game-years, printing a
 //!   summary table. Run with `cargo test -- --ignored --nocapture`.
 //!
-//! Gameplay actions still roll `thread_rng` (full determinism is Track B),
-//! so assertions here are distributional or mechanical, never exact-value.
+//! Determinism: worldgen, the weekly world update, and (since Track B)
+//! every player-action roll derive from `world_seed`, so a seed plus a
+//! policy replays the same career exactly — exact-value assertions are
+//! fair game. `seeded_worlds_are_reproducible_in_the_harness` pins this.
 
 use super::*;
 use std::panic::{AssertUnwindSafe, catch_unwind};

--- a/src/game/timeline.rs
+++ b/src/game/timeline.rs
@@ -111,16 +111,16 @@ impl MusicTimeline {
         self.current_year += 1;
     }
 
-    pub fn get_genre_popularity(&self, genre: &str) -> u8 {
+    pub fn get_genre_popularity(&self, genre: &str, rng: &mut impl rand::Rng) -> u8 {
         let era = self.get_current_era();
         if era
             .dominant_genres
             .iter()
             .any(|g| g.to_lowercase() == genre.to_lowercase())
         {
-            85 + (rand::random::<u8>() % 15) // 85-100
+            rng.gen_range(85..100)
         } else {
-            20 + (rand::random::<u8>() % 60) // 20-80
+            rng.gen_range(20..80)
         }
     }
 

--- a/src/game/world.rs
+++ b/src/game/world.rs
@@ -12,6 +12,12 @@ pub struct PotentialDealOffer {
     pub royalty_rate: f32,
     pub albums_required: u8,
     pub original_label_data: RecordLabel,
+    /// The week the label withdraws the offer if it's ignored. `None`
+    /// means it never expires — deliberately, because offers saved before
+    /// expiry existed deserialize to `None`, and a bare numeric default
+    /// (0) would kill every live offer the moment an old save loaded.
+    #[serde(default)]
+    pub expires_week: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -726,6 +732,9 @@ impl GameWorld {
                             royalty_rate,
                             albums_required,
                             original_label_data: label.clone(),
+                            // The world has no clock; the game stamps the
+                            // deadline when the offer lands on the table.
+                            expires_week: None,
                         });
                     }
                 }

--- a/src/game/world.rs
+++ b/src/game/world.rs
@@ -170,6 +170,14 @@ pub const CHART_SIZE: usize = 10;
 const CHART_DECAY: f32 = 0.85;
 const CHART_FLOOR_SCORE: u32 = 25;
 
+// Deal-offer buzz: the scale the tier thresholds in record_labels.json
+// measure (independent 10, boutique 20, major 30). Fame carries most of it;
+// records prove you can deliver; a charting record adds short-lived heat.
+const BUZZ_PER_SINGLE: u32 = 3;
+const BUZZ_PER_ALBUM: u32 = 4;
+const BUZZ_CATALOG_CAP: u32 = 10;
+const BUZZ_CHART_BONUS: u32 = 2;
+
 impl GameWorld {
     pub fn new(data_files: &GameDataFiles, rng: &mut impl Rng) -> Self {
         Self {
@@ -621,6 +629,33 @@ impl GameWorld {
         demand_mod * saturation_penalty * economic_mod
     }
 
+    /// Industry buzz: how loudly the trade papers talk about an act. This is
+    /// the scale the label tier thresholds in record_labels.json measure
+    /// (independent 10, boutique 20, major 30).
+    ///
+    /// Intent: tiers unlock along a real career arc, not on fame alone.
+    /// Fame is the backbone (3 buzz per 10 fame), the catalog widens each
+    /// window (a single is 3, an album 4 — proof you deliver records), and
+    /// a record on this week's chart adds a little heat while it lasts.
+    /// The catalog contribution is capped so a deep back-catalog can pull
+    /// an act one tier up, but never substitutes for genuine stardom.
+    /// Where that lands, with the JSON thresholds also applying:
+    /// independents around fame ~25 with a first record out, boutiques in
+    /// the ~45-60 mid-career, majors only for genuinely big acts (fame
+    /// ~65+ cold, ~60 while a record is charting).
+    fn band_buzz(&self, band: &Band) -> u8 {
+        let fame_heat = u32::from(band.fame) * 3 / 10;
+        let catalog_heat = (band.singles_released.len() as u32 * BUZZ_PER_SINGLE
+            + band.albums_released.len() as u32 * BUZZ_PER_ALBUM)
+            .min(BUZZ_CATALOG_CAP);
+        let chart_heat = if self.charts.iter().any(|entry| entry.is_player) {
+            BUZZ_CHART_BONUS
+        } else {
+            0
+        };
+        (fame_heat + catalog_heat + chart_heat).min(100) as u8
+    }
+
     pub fn generate_deal_offers(
         &self,
         band: &Band,
@@ -629,6 +664,7 @@ impl GameWorld {
     ) -> Vec<PotentialDealOffer> {
         let mut offers = Vec::new();
         let labels_data = game_data.get_record_labels_data();
+        let buzz = self.band_buzz(band);
 
         let label_tiers = [
             ("Major", &labels_data.major_labels, &labels_data.label_requirements.major_label_interest_threshold),
@@ -638,14 +674,14 @@ impl GameWorld {
 
         for (tier_name, labels_in_tier, threshold) in &label_tiers {
             for label in *labels_in_tier {
-                // Check if band meets threshold
-                // Placeholder for buzz: use band.fame / 10 for now, or a fixed value like 50
-                let buzz_placeholder = band.fame / 5; // Example placeholder
-
+                // The `singles` column reads as "records out, of any kind":
+                // an album on the shelf opens doors at least as well as a
+                // 45, so an act that went straight to albums isn't
+                // invisible to every A&R desk in town.
                 if band.fame >= threshold.fame &&
                    band.albums_released.len() >= threshold.albums as usize &&
-                   band.singles_released.len() >= threshold.singles as usize &&
-                   buzz_placeholder >= threshold.buzz {
+                   band.total_releases() >= threshold.singles as usize &&
+                   buzz >= threshold.buzz {
 
                     // Check if already signed with this label
                     if let Some(current_deal) = band.current_deal()
@@ -827,5 +863,148 @@ mod tests {
         assert_eq!(poached.as_deref(), Some(biggest.as_str()));
         let signed = world.bands.iter().find(|b| b.name == biggest).unwrap();
         assert_eq!(signed.label.as_deref(), Some("Apex Records"));
+    }
+
+    // --- Deal scouting: label tiers unlock along a real career arc ---
+
+    use crate::game::music::{Release, ReleaseType};
+
+    fn record(release_type: ReleaseType) -> Release {
+        Release {
+            id: 0,
+            name: "Test Record".to_string(),
+            release_type,
+            release_quality: 50,
+            week_released: 0,
+            songs_involved_quality_avg: 50,
+            active_marketing: Vec::new(),
+            marketing_level_achieved: 0,
+            initial_sales_score: 0,
+            total_income_generated: 0,
+            genre: None,
+            copies_pressed: 0,
+            copies_sold: 0,
+        }
+    }
+
+    /// A player band with the given fame and catalog.
+    fn act(fame: u8, singles: usize, albums: usize) -> Band {
+        Band {
+            fame,
+            singles_released: (0..singles).map(|_| record(ReleaseType::Single)).collect(),
+            albums_released: (0..albums).map(|_| record(ReleaseType::Album)).collect(),
+            ..Band::default()
+        }
+    }
+
+    /// Which tiers ever bite across plenty of offer rolls. The threshold
+    /// gates are deterministic — only the per-label coin flip is random —
+    /// so enough rolls make an unlocked tier impossible to miss, while a
+    /// locked tier stays silent on every single roll.
+    fn tiers_scouting(
+        world: &GameWorld,
+        data: &GameDataFiles,
+        band: &Band,
+    ) -> std::collections::HashSet<String> {
+        let mut rng = StdRng::seed_from_u64(77);
+        let mut tiers = std::collections::HashSet::new();
+        for _ in 0..40 {
+            for offer in world.generate_deal_offers(band, data, &mut rng) {
+                tiers.insert(offer.label_tier);
+            }
+        }
+        tiers
+    }
+
+    #[test]
+    fn independent_labels_scout_a_working_act_early() {
+        let data = GameDataFiles::load().expect("data files present");
+        let world = GameWorld::new(&data, &mut StdRng::seed_from_u64(31));
+
+        // Local fame and a first single out: indies bite, nobody bigger.
+        let tiers = tiers_scouting(&world, &data, &act(25, 1, 0));
+        assert!(
+            tiers.contains("Independent"),
+            "a fame-25 act with a single out should draw indie interest, got {tiers:?}"
+        );
+        assert!(!tiers.contains("Boutique"), "boutiques should wait for the mid-career");
+        assert!(!tiers.contains("Major"), "majors do not scout the small clubs");
+
+        // The same noise with nothing on the shelves draws nobody at all.
+        let all_talk = tiers_scouting(&world, &data, &act(30, 0, 0));
+        assert!(all_talk.is_empty(), "no catalog, no offers, got {all_talk:?}");
+
+        // An act that went straight to an album is a record out all the
+        // same — not invisible for lacking a 45.
+        let album_first = tiers_scouting(&world, &data, &act(25, 0, 1));
+        assert!(
+            album_first.contains("Independent"),
+            "an album counts as a record out, got {album_first:?}"
+        );
+    }
+
+    #[test]
+    fn boutique_labels_court_the_mid_career_act() {
+        let data = GameDataFiles::load().expect("data files present");
+        let world = GameWorld::new(&data, &mut StdRng::seed_from_u64(31));
+
+        let tiers = tiers_scouting(&world, &data, &act(50, 2, 1));
+        assert!(
+            tiers.contains("Boutique"),
+            "a fame-50 act with a small catalog should draw boutique interest, got {tiers:?}"
+        );
+        assert!(!tiers.contains("Major"), "majors should still be out of reach at fame 50");
+    }
+
+    #[test]
+    fn major_labels_only_sign_genuinely_big_acts() {
+        let data = GameDataFiles::load().expect("data files present");
+        let world = GameWorld::new(&data, &mut StdRng::seed_from_u64(31));
+
+        // An album and three singles out, but fame 60: the majors keep watching.
+        let almost = tiers_scouting(&world, &data, &act(60, 3, 1));
+        assert!(
+            !almost.contains("Major"),
+            "fame 60 should not yet be enough for the majors, got {almost:?}"
+        );
+        assert!(almost.contains("Boutique"), "the mid tiers should be all over them though");
+
+        // Ten more points of fame and the phone rings. (Under the old
+        // placeholder — buzz = fame/5 against a threshold of 30 — no major
+        // could call even at fame 100.)
+        let star = tiers_scouting(&world, &data, &act(70, 3, 1));
+        assert!(
+            star.contains("Major"),
+            "a fame-70 act with a real catalog should finally draw a major, got {star:?}"
+        );
+
+        // But no album, no major — singles alone don't prove you can
+        // deliver the LPs a major contract is made of.
+        let no_album = tiers_scouting(&world, &data, &act(70, 4, 0));
+        assert!(
+            !no_album.contains("Major"),
+            "majors require an album in the catalog, got {no_album:?}"
+        );
+    }
+
+    #[test]
+    fn buzz_weighs_the_catalog_and_a_charting_record() {
+        let data = GameDataFiles::load().expect("data files present");
+        let mut world = GameWorld::new(&data, &mut StdRng::seed_from_u64(31));
+
+        // Same fame, deeper catalog: more buzz...
+        assert!(world.band_buzz(&act(50, 2, 1)) > world.band_buzz(&act(50, 0, 0)));
+        // ...but a shelf of records alone never adds up to stardom.
+        assert_eq!(
+            world.band_buzz(&act(0, 10, 10)),
+            BUZZ_CATALOG_CAP as u8,
+            "the catalog contribution is capped"
+        );
+
+        // A record on this week's chart adds heat while it lasts.
+        let star = act(60, 3, 1);
+        let cold = world.band_buzz(&star);
+        world.submit_chart_entry("The Hit".into(), "The Test Pattern".into(), true, 5_000);
+        assert_eq!(world.band_buzz(&star), cold + BUZZ_CHART_BONUS as u8);
     }
 }

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -414,11 +414,21 @@ fn draw_deals_modal(frame: &mut Frame, app: &App) {
         frame.render_widget(block, area);
 
         let data = &offer.original_label_data;
-        let lines = vec![
+        let mut lines = vec![
             Line::from(""),
             Line::from(format!("  Advance          {}", format_money(offer.advance as i32))),
             Line::from(format!("  Royalty rate     {:.1}%", offer.royalty_rate * 100.0)),
             Line::from(format!("  Albums required  {}", offer.albums_required)),
+        ];
+        if let Some(deadline) = offer.expires_week {
+            let weeks_left = deadline.saturating_sub(app.game.week);
+            lines.push(Line::from(format!(
+                "  Offer expires in {} week{}",
+                weeks_left,
+                if weeks_left == 1 { "" } else { "s" }
+            )));
+        }
+        lines.extend([
             Line::from(""),
             Line::styled("  About the label", Style::new().fg(Color::Cyan).bold()),
             Line::from(format!("  Market reach       {}/100", data.market_reach)),
@@ -428,7 +438,7 @@ fn draw_deals_modal(frame: &mut Frame, app: &App) {
             Line::from(format!("  Reputation: {}", data.reputation)),
             Line::from(""),
             Line::styled("  [A]ccept · [R]eject · [Esc] back", Style::new().fg(Color::DarkGray)),
-        ];
+        ]);
         frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
     } else {
         let items: Vec<ListItem> = offers


### PR DESCRIPTION
HANDOFF.md Track B, **rebased onto Track F by the coordinator** — merge [#11](https://github.com/nrynss/rocker/pull/11) first; this PR's diff then collapses to Track B's two commits.

**The determinism story is now complete**: same seed + same player choices = the same career, bit for bit. Every player-action roll (song/recording quality, write counts, tour rolls, support offers, random events, historical-event consequences, deal generation) draws from a per-week action RNG derived from `world_seed` via the same splitmix64 finalizer as the world stream, salted with a distinct stream constant so the two streams never correlate. `rg thread_rng src/game/` is empty. No serialized RNG state — streams re-key from `(seed, week)`, so save/load needs nothing.

- **World stream untouched and proven bit-identical** to baseline via a temporary fingerprint run (not just inspection).
- **Proof test** `same_seed_and_same_choices_replay_the_same_career`: two games, seed 2025, an identical scripted 20-turn career (writes, gigs, a club-run single, a 4-week break) → identical week, money, fame, and the accumulated log **line-for-line**; seed 2026 must diverge.
- Two ambient-RNG holes beyond the task list were found and sealed (data_loader title/name generators, a dead timeline fn).
- HashMap-iteration audit: no order-dependent gameplay found.
- sim.rs docs updated; the harness reproducibility test now replays a 2-year career exactly.

**Coordinator integration notes:** the rebase over Track F had two conflicts in the shared deal-offer region, resolved by combining F's expiry logic with B's seeded-RNG signature (F's new tests now take an explicit RNG). Verified on the combined result: **41 tests + both ignored sweeps pass** (with F's scouting fix + determinism together, balanced-indie wins 44/48 by year 12, median win week 218), clippy zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)