### PR TITLE
fix: historical genre events now respect the band's genre

### DIFF
--- a/src/game/band.rs
+++ b/src/game/band.rs
@@ -168,12 +168,26 @@ impl Band {
         self.singles_released.len() + self.albums_released.len()
     }
 
+    /// Whether the band's genre answers to any of the given labels. Matching
+    /// is tolerant of surface form: "Hair Metal" and "hair_metal" both match
+    /// Metal (via [`MusicGenre::aliases`]), "Grunge" matches Alternative, and
+    /// so on — so historical events can name sub-genres the coarse enum folds
+    /// together. A label that maps to no genre (e.g. "Folk Rock") simply
+    /// matches nothing.
     pub fn dominant_genres_match(&self, target_genres: &[&str]) -> bool {
-        // This is a simplified check - in a full implementation,
-        // the band would have a genre field
-        // For now, we'll use a placeholder that returns true for any genre
-        // TODO: Add actual genre tracking to Band struct
-        !target_genres.is_empty() // Placeholder - always return true if genres provided
+        fn normalize(s: &str) -> String {
+            s.chars()
+                .filter(|c| c.is_ascii_alphanumeric())
+                .map(|c| c.to_ascii_lowercase())
+                .collect()
+        }
+        let keys: Vec<String> = std::iter::once(self.genre.name())
+            .chain(self.genre.aliases().iter().copied())
+            .map(normalize)
+            .collect();
+        target_genres
+            .iter()
+            .any(|target| keys.iter().any(|key| *key == normalize(target)))
     }
 
     pub fn current_deal(&self) -> Option<&RecordDeal> {

--- a/src/game/tests/history.rs
+++ b/src/game/tests/history.rs
@@ -1,0 +1,53 @@
+//! Historical events reward or penalize by the band's actual genre.
+
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+
+use super::*;
+
+/// Regression: `dominant_genres_match` once ignored the band's genre and
+/// returned true for any non-empty list, so every dated event fired for
+/// every band — the Beatles windfall paid everyone and the grunge shake-up
+/// rewarded everyone while its hair-metal penalty was unreachable. Events
+/// must now touch only the genres they name.
+#[test]
+fn historical_genre_events_respect_the_band_genre() {
+    // Fame delta from applying `event` to a band playing `g` (fame moves are
+    // deterministic; the money side draws from rng and isn't asserted).
+    let delta = |event: &str, g: genre::MusicGenre| {
+        let mut game = test_game();
+        game.band.genre = g;
+        game.band.fame = 50;
+        let before = game.band.fame;
+        game.apply_historical_event(event, &mut StdRng::seed_from_u64(0))
+            .expect("historical events always apply");
+        game.band.fame as i16 - before as i16
+    };
+
+    // "Grunge emerges": alternative acts surge, the hair-metal crowd sinks,
+    // and an unrelated genre is left alone.
+    assert!(
+        delta("Grunge emerges", genre::MusicGenre::Alternative) > 0,
+        "grunge should lift an alternative act"
+    );
+    assert!(
+        delta("Grunge emerges", genre::MusicGenre::Metal) < 0,
+        "grunge should bury the hair-metal crowd (penalty was unreachable)"
+    );
+    assert_eq!(
+        delta("Grunge emerges", genre::MusicGenre::Pop),
+        0,
+        "an unrelated genre should be untouched by the grunge shake-up"
+    );
+
+    // The Beatles' break-up rewards rock, not everyone.
+    assert!(
+        delta("The Beatles break up", genre::MusicGenre::Rock) > 0,
+        "a rock act should ride the post-Beatles moment"
+    );
+    assert_eq!(
+        delta("The Beatles break up", genre::MusicGenre::Pop),
+        0,
+        "a pop act should not be paid by the Beatles event"
+    );
+}

--- a/src/game/tests/mod.rs
+++ b/src/game/tests/mod.rs
@@ -14,6 +14,7 @@ use super::*;
 mod deals;
 mod determinism;
 mod fame;
+mod history;
 mod releases;
 mod save_compat;
 mod smoke;


### PR DESCRIPTION
## The bug

`Band::dominant_genres_match` (`src/game/band.rs`) was a leftover placeholder:

```rust
!target_genres.is_empty() // always true for a non-empty list
```

It ignored the band's `genre` field entirely, so every dated historical event in `apply_historical_event` (`src/game/events_apply.rs`) fired for **every** band:

- **The Beatles break-up** paid its +5 fame / +$200 windfall to all genres.
- **"Grunge emerges"** rewarded everyone with +12 fame and big money, and its intended hair-metal penalty — an `else if` sitting after an always-true branch — was **unreachable**.

## The fix

Match the band's genre against the given labels using `MusicGenre::name()` and `aliases()`, normalized to lowercase alphanumerics so event labels like `"Hair Metal"` / `"Grunge"` line up with the existing `aliases()` keys (`"hair_metal"`, `"grunge"`). A label that maps to no genre (e.g. `"Folk Rock"`) now matches nothing instead of everything.

Net effect:
- Beatles event → rewards **Rock**, not Pop.
- Grunge event → **Alternative** surges, **Metal** takes the −8 penalty (now reachable), everyone else untouched.

## Test

New `src/game/tests/history.rs` asserts the genre gating on fame deltas (deterministic; money draws from rng and isn't asserted). It **fails against the old placeholder** — verified by reverting only `band.rs`, at which point the `Metal` penalty assertion panics with *"penalty was unreachable"*.

- `cargo test` — 43 passed / 0 failed / 2 ignored (was 42; +1 new)
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean

No save-format or RNG-stream changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Historical genre events now affect only bands whose genres match the event, preventing unrelated genres from being changed.
  * Genre matching now recognizes aliases and formatting variations, including differences in capitalization and punctuation.

* **Tests**
  * Added coverage for genre-specific effects from historical events, including examples involving Grunge, Alternative, Metal, Pop, and Rock.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->