### PR TITLE
docs: open the v0.6 Life Cycle — design doc + handoff board

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -190,6 +190,7 @@ cargo clippy --all-targets -- -D warnings
 cargo fmt --check
 # contracts:
 cargo test same_seed_and_same_choices_replay_the_same_career
+cargo test seeded_worlds_are_reproducible_in_the_harness
 cargo test saves_from_v0_4_still_load
 cargo test worldgen_is_reproducible_per_seed
 # balance lab (ignored sweeps, run locally when tuning):

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,497 +1,168 @@
-# Rocker — Structure Hardening Handoff (v0.5.1)
+# Rocker — Life Cycle Handoff (v0.6)
 
-> **Active cycle.** Pure structural refactor so the next feature cycle
-> (Musician / FUTURE.md §1–§6) lands in small, owned files. **No gameplay
-> behavior changes.** No formula tuning. No Musician implementation yet.
+> **Active cycle.** Feature cycle: the four bars (health/stress/happiness/
+> creativity), per-show concert analysis, fame gravity with peak floors,
+> living sales tail, endless post-rockstar play, and JSON-driven incidents.
+> **Design is decided** — read `docs/DESIGN-v0.6-life-cycle.md` before
+> claiming anything. Numbers marked [tune] there are sim-lab-validated, not
+> invented per-agent.
 >
-> Prior cycle: `docs/archive/HANDOFF-v0.5-cycle.md` · What shipped: `CHANGELOG.md`
-> · Design north star (later): `FUTURE.md`
+> Prior cycles: `docs/archive/HANDOFF-v0.5-cycle.md` (features),
+> `docs/archive/HANDOFF-v0.5.1-structure.md` (structure) · Shipped:
+> `CHANGELOG.md` · North star for the *next* cycle: `FUTURE.md` (Musician).
+> **Deferred:** drugs/addiction (§9.1), vacations picker (§9.3), manager
+> (§9.4) — do not implement, do not remove the dormant fields.
 
-Baseline on start of cycle: **0.5.0**, `cargo test` → **42 passed, 2 ignored**,
-clippy clean, `thread_rng` gone, `src/game/mod.rs` ~1 060 lines of which
-~750 are tests.
+Baseline at cycle start: **0.5.1**, `cargo test` → **43 passed, 2 ignored**,
+clippy clean, fmt clean. Cycle closes as **0.6.0**.
 
 ---
 
 ## How agents claim work
 
-This handoff is the **single coordination surface**. Do not start a task
-that is already claimed or whose prerequisites are not ✅.
+Same protocol as the structure cycle — this file is the **single
+coordination surface**. Do not start a task that is claimed or whose
+prerequisites are not ✅.
 
 ### One branch for the whole cycle
 
-**All structure work lands on `struct/t4-genre`.** Do not open
-`struct/t1-…`, `struct/t5-…`, or any other task branch. Multi-branch
-parallelism caused rebase pain and split history; coordination is the
-**board + exclusive Owns**, not git branches.
+**All work lands on `life/v0.6`.** No per-task branches.
 
 ```text
 git fetch origin
-git checkout struct/t4-genre
-git pull --rebase origin struct/t4-genre   # always before claim / before push
+git checkout life/v0.6
+git pull --rebase origin life/v0.6   # always before claim / before push
 # … do one claimed task …
-git push origin struct/t4-genre
+git push origin life/v0.6
 ```
 
 If `pull --rebase` conflicts in files you do **not** own, stop and
-unclaim — do not “fix” another agent’s WIP.
+unclaim — do not "fix" another agent's WIP.
 
 ### Claim protocol (mandatory)
 
-1. **On `struct/t4-genre`**, up to date with `origin` (see above).
-2. **Read this whole file**, then the task section for the ID you want.
+1. **On `life/v0.6`**, up to date with `origin`.
+2. **Read the design doc**, then this whole file, then your task section.
 3. **Prerequisites:** every ID in `Prereqs` must be `✅ done` (or `—`).
-4. **Claim atomically** — edit the Task board row in the **same commit**
-   that starts the work (or a tiny commit immediately before code):
-   - `Status`: `⬜ open` → `🔒 claimed`
-   - `Claimed by`: short agent/session id (e.g. `claude-a3f2`, `grok-struct-1`)
-   - `Branch` column: always `struct/t4-genre` (shared; do not invent a name)
-5. **While working**, you own every path listed under **Owns**. Do not
-   edit another open/`🔒 claimed` task’s owned files. If you must touch
-   shared wiring (`src/game/mod.rs` module list, `src/ui/mod.rs`), keep
-   the diff to the minimum `mod` / `pub use` lines.
-6. **Done means green**, then update the board and **push the same branch**:
-   - `Status`: `🔒 claimed` → `✅ done`
-   - Fill `Done` with the commit short SHA that completed the task
-   - Leave `Claimed by` as historical record
-7. **Unclaim** if you abort: set `Status` back to `⬜ open`, clear
-   `Claimed by`, and say why in one line under Notes.
+4. **Claim atomically** — flip the board row in the same commit that
+   starts the work: `Status` → `🔒 claimed`, `Claimed by` → agent id.
+5. **You own every path under Owns** while claimed. Shared wiring
+   (`mod` / `pub use` lines in `mod.rs` files) — minimum diff only.
+6. **Done means green** (`cargo test`, clippy `-D warnings`, fmt) plus
+   the task's own acceptance line. Flip to `✅ done`, fill `Done` SHA,
+   push the shared branch.
+7. **Unclaim** if you abort: back to `⬜ open`, clear `Claimed by`, one
+   line under Notes saying why.
 
-### Status legend
-
-| Mark | Meaning |
-|------|---------|
-| `⬜ open` | Available if prereqs are done |
-| `🔒 claimed` | An agent is actively working it — **do not take** |
-| `✅ done` | Merged / complete; safe as a prerequisite |
-| `⏸ blocked` | Waiting on human decision (should be rare this cycle) |
+Commit prefix: `life(L#): <short description>`.
 
 ### Ground rules (every agent)
 
-- **Pure moves only.** No behavior changes, balance tweaks, log-line
-  rewrites, or “while I’m here” formula fixes. If a test fails after a
-  move, you restored visibility wrong — fix the move, don’t “fix” the game.
-- **Verify before claiming done:**
-  ```text
-  cargo test
-  cargo clippy --all-targets -- -D warnings
-  cargo fmt --check
-  ```
-  Same test **names** and **count** (42 + 2 ignored) unless the task
-  explicitly relocates tests (names must still match).
-- **Serde / saves:** do not rename serialized fields. Re-exports are fine;
-  on-disk shape is sacred (`tests/fixtures/pre-0.5.sav` must keep loading).
-- **RNG draw order is sacred.** Moving code must not reorder
-  `gen_*` calls on a stream. The determinism tests
+- **This cycle changes behavior on purpose** — but only *your task's*
+  behavior. No drive-by balance edits outside your Owns; every [tune]
+  number you set must match the design doc or carry a Notes line saying
+  what you changed and why.
+- **Tests:** unlike the structure cycle, test counts will grow and some
+  assertions will legitimately change. Never delete a test to make it
+  pass; adapt it and say so in the commit. The determinism tests
   (`same_seed_and_same_choices_replay_the_same_career`,
   `seeded_worlds_are_reproducible_in_the_harness`,
-  `worldgen_is_reproducible_per_seed`) are the contract — if they fail,
-  you reshuffled draws; undo.
-- **Visibility:** prefer `pub(super)` / `pub(crate)` over `pub`. Integration
-  tests are **not** the goal this cycle; keep unit-test access via
-  `#[cfg(test)]` modules under `src/game/`.
-- **One shared branch:** `struct/t4-genre` only. Commit message prefix:
-  `struct(T#): <short description>`. One open PR from this branch to
-  `main` when the cycle closes (or whenever the human merges); agents
-  push commits, they do not open parallel task PRs.
-- **Update this file** when claiming and when completing, on the same
-  branch as the code.
+  `worldgen_is_reproducible_per_seed`) must pass **unmodified**.
+- **Serde / saves:** every new field `#[serde(default)]`. Never rename
+  serialized fields (`energy` and addiction fields stay, dormant).
+  `saves_from_v0_4_still_load` and the pre-0.5 fixture are sacred.
+- **RNG:** new rolls draw on the existing streams — per-show and incident
+  rolls on the **action stream**, world evolution on the **world stream**.
+  Never reintroduce `thread_rng` under `src/`.
+- **Visibility:** prefer `pub(super)` / `pub(crate)`; keep unit tests in
+  `src/game/tests/` with the existing harness.
 
-### Do-not-undo (still in force from v0.5)
+### Do-not-undo (carried from v0.5 / v0.5.1)
 
-- World + action RNG injection from `world_seed` — never reintroduce
-  `thread_rng` under `src/`.
-- Live fame double-cap, idle decay, pressing/unit economics, label marketing
-  ownership, news-from-state, `MusicGenre` as the single genre enum.
-- Support slots remain deliberately uncapped by catalog fame.
-
-### Out of scope this cycle
-
-- FUTURE.md Musician / abilities / personality
-- Decade pacing, event-fame audit, tour bots, difficulty modes
-- New features, UI chrome, balance passes
-
-Those wait for a **Musician cycle handoff** after this board is all ✅.
+- World + action RNG injection from `world_seed`.
+- Pressing/unit economics, label marketing ownership, news-from-state,
+  `MusicGenre` as the single genre enum, module structure from v0.5.1.
+- Support slots uncapped by catalog fame.
 
 ---
 
 ## Task board (source of truth)
 
-**How to read prereqs:** `—` = none (start when ready). Multiple IDs =
-all must be ✅. Tasks with **disjoint Owns** and satisfied prereqs may
-run **in parallel on the same branch** — never via extra branches.
-
 | ID | Task | Size | Prereqs | Owns (exclusive) | Status | Claimed by | Branch | Done |
 |----|------|------|---------|------------------|--------|------------|--------|------|
-| **T1** | Extract `game` unit tests out of `mod.rs` into `src/game/tests/` | M | — | `src/game/mod.rs` *(tests module only + `mod tests` wiring)*, **new** `src/game/tests/**` | ✅ done | claude-t1 | struct/t4-genre | 78f93a5 |
-| **T2** | Extract tuning knobs → `src/game/constants.rs` | S | T1 | `src/game/constants.rs` *(new)*, `src/game/mod.rs` *(const block → re-export)*, imports in modules that referenced parent consts | ✅ done | pier-t2 / grok-t2-polish | struct/t4-genre | 40aadef |
-| **T3** | Extract `Game` / `GameAction` / lifecycle → `src/game/core.rs`; thin `mod.rs` | S | T2 | `src/game/core.rs` *(new)*, `src/game/mod.rs` *(shell)*, `src/game/tests/**` *(paths/`use` only if needed)* | ✅ done | antigravity | struct/t4-genre | ea15990 |
-| **T4** | Extract `MusicGenre` → `src/game/genre.rs` | S | — | `src/game/genre.rs` *(new)*, `src/game/world.rs` *(remove genre)*, all `use` sites of `MusicGenre` | ✅ done | grok-struct-t4 | struct/t4-genre | 860fb6f |
-| **T5** | Split `actions.rs` → `actions/{mod,studio,live,business,rest}.rs` | M | — | `src/game/actions.rs` → `src/game/actions/**` only | ✅ done | grok-struct-t5 | struct/t4-genre | b601eab |
-| **T6** | Split event *outcomes* out of `turn.rs` → `events_apply.rs` | S | — | `src/game/turn.rs`, **new** `src/game/events_apply.rs`, `src/game/mod.rs` *(one `mod` line)* | ✅ done | pier-t6 | struct/t4-genre | 567f348 |
-| **T7** | Split `world.rs` → `world/{mod,scene,charts,deals,venues}.rs` | L | T4 | `src/game/world.rs` → `src/game/world/**`, world unit tests relocate with code | ✅ done | grok-struct-t7 | struct/t4-genre | ba6a74c |
-| **T8** | Optional: `src/game/rng.rs` (action-stream helpers only) | S | T3 | `src/game/rng.rs` *(new)*, `src/game/core.rs`, `src/game/turn.rs` *(import paths)* | ✅ done | grok-struct-t8 | struct/t4-genre | 28596c5 |
-| **T9** | Split UI input handlers out of `app.rs` | M | — | `src/ui/app.rs`, **new** `src/ui/input/**` (or `src/ui/input.rs` + submodules), `src/ui/mod.rs` | ✅ done | antigravity | struct/t4-genre | 043ccf8 |
-| **T10** | Split UI drawing out of `render.rs` | M | — | `src/ui/render.rs`, **new** `src/ui/render/**`, `src/ui/mod.rs` | ✅ done | antigravity | struct/t4-genre | 7258107 |
-| **T12** | Split `render/modals.rs` → `modals/{deals,charts,marketing,file,pickers}` | S | T10 | `src/ui/render/modals.rs` → `src/ui/render/modals/**` only | ✅ done | grok-struct-t12 | struct/t4-genre | 356d957 |
-| **T11** | Cycle close: line-count report, board audit, archive note | S | T1–T7, T9–T10, T12 *(T8 optional)* | `HANDOFF.md`, optional short note in `CHANGELOG.md` under Internal | ✅ done | claude-t11 | struct/t4-genre | d7b1e59 |
+| **L1** | Stat engine: four bars, weekly tick, stress economy | M | — | `src/game/player.rs`, `src/game/actions/rest.rs`, **new** `src/game/lifestyle.rs`, stat consts in `src/game/constants.rs`, one call-site line in `turn.rs` | ⬜ open | | life/v0.6 | |
+| **L2** | Writing & quality rework (creativity-driven, consumption rules, happiness multiplier) | S | L1 | `src/game/actions/studio.rs`, `writing_streak` field on `Game` in `core.rs` | ⬜ open | | life/v0.6 | |
+| **L3** | Per-show engine: reception, box office, momentum; gig + tour rework; report storage | L | L1 | **new** `src/game/shows.rs`, `src/game/actions/live.rs`, `last_tour_report` field in `core.rs` | ⬜ open | | life/v0.6 | |
+| **L4** | Tour report modal + four-bar panel UI | M | L3 | **new** `src/ui/render/modals/tour.rs`, `src/ui/render/panels.rs`, `src/ui/input/main.rs`, `mod`/`pub use` lines in `ui/render/modals/mod.rs` | ⬜ open | | life/v0.6 | |
+| **L5** | Fame gravity: peak floors, tiered grace, ramp, comeback ×2, activity rules, hit tracking | L | — | `src/game/turn.rs` (visibility + game-over fns), `peak_fame` in `band.rs`, `peak_chart_position` in `music.rs`, chart-position write-back in `economy.rs` (that line only), fame consts in `constants.rs` | ⬜ open | | life/v0.6 | |
+| **L6** | Label single-cuts (label releases a single on its own volition) | S | L5 | **new** `src/game/label_moves.rs`, one call-site line in `turn.rs`, single-cut tracking on `Release`/album in `music.rs` | ⬜ open | | life/v0.6 | |
+| **L7** | Living sales tail (gentler divisor, marketing/fame-responsive, fix dead post-launch marketing) | S | — | `src/game/economy.rs` (catalog-tail section), tail consts in `constants.rs` | ⬜ open | | life/v0.6 | |
+| **L8** | Incidents → `data/incidents.json`: schema, loader, weighted selection, migrate + new content, cadence up | M | L1 | **new** `data/incidents.json`, `src/data_loader.rs`, `src/game/events.rs`, `src/game/events_apply.rs` | ⬜ open | | life/v0.6 | |
+| **L9** | Endless game: rockstar becomes milestone, not ending | S | L5 | `rockstar_achieved` in `core.rs`, milestone logic in `turn.rs` (game-over fn), `src/ui/render/game_over.rs` | ⬜ open | | life/v0.6 | |
+| **L10** | Sim-lab validation: sweeps for [tune] values, income/fame trajectory report, new-system bot coverage | M | L1–L3, L5–L8 | `src/game/sim.rs`, `src/game/tests/**` (new test files), Notes below | ⬜ open | | life/v0.6 | |
+| **L11** | Cycle close: board audit, CHANGELOG, bump 0.6.0, PR to main | S | all | `HANDOFF.md`, `CHANGELOG.md`, `Cargo.toml`/`Cargo.lock` | ⬜ open | | life/v0.6 | |
 
 ### Parallelism map (waves)
 
 ```text
-Wave 0 (immediate, fully parallel — disjoint owns):
-  T1 (game tests)     T4 (genre)     T5 (actions)     T6 (events_apply)
-  T9 (ui input)       T10 (ui render)
+Wave 0 (fully parallel — disjoint owns):
+  L1 (stat engine)    L5 (fame gravity)    L7 (sales tail)
 
 Wave 1:
-  T2 (constants)      ← after T1
-  T7 (world split)    ← after T4
-  T12 (modals split)  ← after T10  (parallel with T7 — disjoint owns)
+  L2 (writing/quality) ← L1        L3 (per-show engine) ← L1
+  L8 (incidents JSON)  ← L1        L6 (label cuts)      ← L5
+  L9 (endless game)    ← L5
 
 Wave 2:
-  T3 (core.rs shell)  ← after T2
-  T8 (rng.rs)         ← after T3, optional
+  L4 (tour report UI)  ← L3
+  L10 (sim validation) ← L1–L3, L5–L8
 
 Wave 3:
-  T11 (close)         ← after required tasks (incl. T12)
+  L11 (close)          ← all
 ```
 
-**Conflict warnings (same branch — Owns are the mutex):**
+**Conflict warnings (Owns are the mutex):**
 
 | Pair | Issue |
-|------|--------|
-| T1 ∥ T2 ∥ T3 | All touch `mod.rs` — **serialized** by prereqs (T1→T2→T3) |
-| T4 ∥ T7 | T7 must wait for T4 so genre is not moved twice |
-| T9 ∥ T10 | Both may touch `ui/mod.rs` — only add `mod` lines; never reformat the other’s files. Prefer one claimed at a time if unsure |
-| T12 ∥ T7 | Fully parallel — UI modals vs game world; no shared paths |
-| T6 | May add one `mod events_apply;` line in `game/mod.rs` while T1–T3 run — pull --rebase; keep that line-only |
-| Any ∥ any | **Pull --rebase before push.** Do not force-push unless the human says so |
+|------|-------|
+| L1 ∥ L5 | Both add one line to `turn.rs` — L1 gets exactly one call-site line for the weekly tick; L5 owns the rest of `turn.rs`. Rebase, keep diffs line-scoped. |
+| L5 → L6 → L9 | All touch `turn.rs` — serialized by prereqs. |
+| L2 ∥ L3 | Both add a field to `core.rs` — field + accessor lines only; rebase. |
+| L5 ∥ L7 | Both touch `economy.rs` — L7 owns the catalog-tail section; L5 only the chart-position write-back line at launch resolution. Coordinate via Notes if unsure. |
+| L1 ∥ L2 ∥ L3 | Stress costs for studio/live actions belong to L2/L3 respectively, using L1's constants — L1 does not edit `studio.rs`/`live.rs`. |
+| Any ∥ any | Pull --rebase before push. No force-push without the human. |
 
 ---
 
-## Target tree (end state)
-
-```text
-src/game/
-  mod.rs                 # module list + pub use only (≪ 80 lines)
-  constants.rs           # all tuning knobs + design comments
-  core.rs                # Game, GameAction, SupportTourOffer, new/init/save/load
-  rng.rs                 # T8: world/action stream builders + Game::action_rng*
-  genre.rs               # MusicGenre + Display + aliases (+ room for ability_weights later)
-  band.rs
-  player.rs
-  music.rs
-  events.rs              # EventManager / trigger selection (unchanged role)
-  events_apply.rs        # apply_random_event / apply_historical_event bodies
-  economy.rs
-  timeline.rs
-  turn.rs                # process_turn, visibility, offer hooks, game-over
-  actions/
-    mod.rs               # execute_action match only
-    studio.rs            # write, practice, record, quality helpers
-    live.rs              # gig, tour, live_fame_cap, regions
-    business.rs          # deals, marketing, support
-    rest.rs              # laze, break, doctor
-  world/
-    mod.rs               # GameWorld, market, update_week conductor
-    scene.rs             # SceneBand, population, momentum, scene releases
-    charts.rs            # ChartEntry, decay, submit
-    deals.rs             # PotentialDealOffer, buzz, generate, poach
-    venues.rs            # Venue + generation
-  tests/                 # #[cfg(test)] only
-    mod.rs               # harness: test_game, test_release, helpers
-    fame.rs
-    releases.rs          # pressing, charts entry, genre sales, marketing
-    deals.rs
-    support.rs
-    determinism.rs
-    save_compat.rs
-    …                    # split by concern; keep test fn names stable
-  sim.rs                 # balance lab (already test-only) — leave path or
-                         #   `pub mod sim` under tests/ only if T1 chooses to;
-                         #   default: keep `src/game/sim.rs` as today
-
-src/ui/
-  mod.rs
-  app.rs                 # App struct, run loop, thin dispatch
-  input/…                # key handlers by screen
-  render/
-    mod.rs               # draw() conductor + shared helpers
-    layout.rs / panels.rs / setup.rs / game_over.rs
-    modals/              # T12 — overlay family package
-      mod.rs             # re-exports draw_* for render::draw
-      deals.rs           # deals + support offer
-      charts.rs
-      marketing.rs
-      file.rs
-      pickers.rs         # venue, pressing, region
-```
-
-Line-count **soft caps** after the cycle (not enforced by CI):
-
-| Area | Soft max |
-|------|----------|
-| Any single production `.rs` under `game/` or `ui/` | ~400 lines preferred, ~500 hard |
-| `game/mod.rs` | ~80 |
-| `world/mod.rs` conductor | ~200 |
-| `actions/mod.rs` | ~80 |
-
----
-
-## Task details
-
-### T1 — Tests out of `mod.rs`
-
-**Why:** ~750 lines of tests bury the real module surface and force every
-game PR to load a novel.
-
-**Do:**
-
-1. Create `src/game/tests/mod.rs` with the shared harness currently at
-   the top of `mod.rs`’s `#[cfg(test)] mod tests` (`test_game`,
-   `test_release`, `best_open_venue`, `test_deal_offer`, …).
-2. Split tests into concern files (suggested): `fame`, `releases`,
-   `deals`, `support`, `determinism`, `save_compat`, `smoke` — group by
-   what they assert, not 1:1 with production modules.
-3. Wire with:
-   ```rust
-   #[cfg(test)]
-   mod tests;
-   ```
-   in `src/game/mod.rs` (or `game.rs` after T3 — for T1, keep wiring in
-   `mod.rs`).
-4. **Keep every `#[test] fn` name identical** so `cargo test` output and
-   muscle memory stay stable.
-5. Leave `sim.rs` where it is (`src/game/sim.rs` + `#[cfg(test)] mod sim`)
-   unless moving it is trivial; do not merge sim into unit tests.
-
-**Acceptance:**
-
-- `src/game/mod.rs` has **no** `#[test]` functions left
-- `cargo test` → still 42 passed + 2 ignored, **same names**
-- Harness helpers are not `pub` outside `#[cfg(test)]`
-
-**Claim note:** while 🔒, nobody else edits the old tests block in `mod.rs`.
-
----
-
-### T2 — `constants.rs`
-
-**Why:** balance knobs and stream salts should not live beside `Game`’s
-serde shape.
-
-**Do:**
-
-1. Move every tuning `const` / `pub const` currently at the top of
-   `mod.rs` (quality, sales, pressing, fame caps, idle, deals, genre
-   trend thresholds, `ACTION_STREAM_SALT`, `SETUP_STREAM_WEEK`, …) into
-   `src/game/constants.rs`, **keeping comments**.
-2. Re-export anything the UI or others need at the old path if useful:
-   ```rust
-   pub use constants::{PRESSING_TIERS, BREAK_WEEKS};
-   ```
-   so call sites outside `game` need not all change — or update call
-   sites in one go; either is fine if compile-clean.
-3. Modules that used bare `PRESSING_TIERS` via `super::*` should
-   `use crate::game::constants::*` or `super::constants::*` as appropriate.
-
-**Acceptance:** no gameplay consts left in `mod.rs` / `core.rs` except
-re-exports; tests pass unchanged.
-
----
-
-### T3 — `core.rs` thin shell
-
-**Why:** `mod.rs` should only declare submodules.
-
-**Do:**
-
-1. Move `GameAction`, `SupportTourOffer`, `Game`, `default_seed`,
-   `impl Game` lifecycle (`new`, `log`, `take_turn_log`, `action_rng*`,
-   `initialize_player`, `save_game`, `load_game`) into `src/game/core.rs`.
-2. `mod.rs` becomes module declarations + `pub use core::{Game, GameAction, …}`
-   as needed by `main` / `ui`.
-3. Fix `actions` / `economy` / `turn` / `tests` / `sim` imports (`super::Game`
-   still works if they are children of `game` module tree — today they are
-   `mod actions` siblings; keep them as siblings of `core.rs` via
-   `mod core;` and `use crate::game::core::Game` **or** the common pattern:
-   ```rust
-   // mod.rs
-   mod core;
-   pub use core::*;
-   ```
-   Prefer the pattern that minimizes churn in `actions.rs` (`use super::*`).
-
-**Acceptance:** `mod.rs` ≪ 80 lines; `Game::new` / save-compat tests still pass.
-
----
-
-### T4 — `genre.rs`
-
-**Why:** Musician §2 will hang `ability_weights()` on `MusicGenre`. It must
-not live inside a 1k-line world file.
-
-**Do:**
-
-1. Move `MusicGenre` + its `impl` (ALL, name, aliases, random*, Display,
-   Default, Hash, …) to `src/game/genre.rs`.
-2. `pub use` from `world` **or** update all imports to `crate::game::genre::MusicGenre`.
-   Prefer **one** canonical path: `crate::game::genre::MusicGenre`, and a
-   temporary re-export from `world` only if it reduces churn — document
-   which you chose in the PR.
-3. Do **not** move charts/scene/deals yet (that’s T7).
-
-**Acceptance:** `rg "enum MusicGenre" src/` → only `genre.rs`; all tests green.
-
----
-
-### T5 — `actions/` package
-
-**Why:** practice / studio quality will grow with Musician; live and
-business actions should not share a 640-line file.
-
-**Do:** pure file split:
-
-| File | Contents (from current `actions.rs`) |
-|------|--------------------------------------|
-| `actions/mod.rs` | `mod studio; …` + `execute_action` |
-| `actions/studio.rs` | write, practice, record_*, quality helpers, song selection |
-| `actions/live.rs` | gig, tour, `live_fame_cap`, `get_sorted_regions` |
-| `actions/business.rs` | deals, marketing, support accept/decline |
-| `actions/rest.rs` | laze, break, doctor |
-
-Keep methods on `impl Game` with the same `pub(super)` visibility.
-Parent still `mod actions;` in `game/mod.rs` (directory replaces file).
-
-**Acceptance:** no `src/game/actions.rs` file left (only directory);
-`execute_action` still the single match hub; tests green.
-
----
-
-### T6 — `events_apply.rs`
-
-**Why:** `apply_random_event` / historical outcomes are a slab inside
-`turn.rs`; personality will modulate outcomes later.
-
-**Do:**
-
-1. Move `apply_random_event` and `apply_historical_event` (and any private
-   helpers only they use) to `src/game/events_apply.rs` as `impl Game`.
-2. Leave trigger selection in `events.rs` and week orchestration in `turn.rs`.
-3. One new `mod events_apply;` in the game module tree.
-
-**Acceptance:** `turn.rs` drops substantially; event-related tests still pass
-(including full-season smoke / determinism).
-
----
-
-### T7 — `world/` package
-
-**Why:** scene / charts / deals / venues are separate agent surfaces for
-Musician (lazy rosters) and future deal work.
-
-**Prereq T4** so genre is already outside.
-
-**Do:**
-
-| File | Owns |
-|------|------|
-| `world/mod.rs` | `GameWorld`, `MusicMarket`, `EconomicState`, `MusicTrend`, `update_week`, market helpers |
-| `world/scene.rs` | `SceneBand`, generate scene, `update_scene_*`, population bounds consts if scene-local |
-| `world/charts.rs` | `ChartEntry`, decay, submit, chart consts |
-| `world/deals.rs` | `PotentialDealOffer`, buzz consts, `generate_deal_offers`, `poach_rejected_deal` |
-| `world/venues.rs` | `Venue`, `generate_venues` |
-
-Move `#[cfg(test)]` world tests into `world/tests` or bottom of the file
-they assert on — keep test **function names**.
-
-**Acceptance:** no monolithic `src/game/world.rs`; `update_week` remains a
-short conductor; world + deal + chart tests green; scene size still 120–260.
-
----
-
-### T8 — `rng.rs` (optional)
-
-**Why:** documents the sacred stream contract in one place.
-
-**Do only if Wave 2 is calm:** move `ACTION_STREAM_SALT`, `SETUP_STREAM_WEEK`,
-`action_rng_for_week`, `action_rng` into `rng.rs` (constants may stay in
-`constants.rs` with functions in `rng.rs` — pick one and don’t split salts
-from their docs).
-
-**Skip** if T3 already leaves these easy to find; mark board ✅ with note
-`skipped — low value` only with human OK, or leave ⬜ open.
-
----
-
-### T9 — UI input split
-
-**Why:** setup / pickers / modals will grow for Musician UI (FUTURE §6).
-
-**Do:** move `handle_*_key` families out of `app.rs` into e.g.
-`ui/input/{setup,main,deals,marketing,pickers,file}.rs`. Keep `App` and
-`run` / top-level `handle_key` dispatch in `app.rs`.
-
-**Acceptance:** `app.rs` clearly under ~500 lines; setup genre test still
-passes; no input behavior change.
-
----
-
-### T10 — UI render split
-
-**Why:** same as T9 for draw code.
-
-**Do:** split `draw_*` into `ui/render/{layout,panels,modals,…}.rs`.
-Shared style helpers can live in `render/mod.rs`.
-
-**Acceptance:** `render.rs` file gone or thin; visual structure unchanged
-(no drive-by color/layout redesigns).
-
----
-
-### T12 — Split render modals package
-
-**Why:** After T10, `render/modals.rs` was still ~470–500 lines — the
-largest remaining UI file. Musician UI will add more overlays; keep each
-modal family small. **Not part of T7** (game world); parallel-safe.
-
-**Prereq:** T10 ✅.
-
-**Do:** pure move only:
-
-| File | Contents |
-|------|----------|
-| `modals/mod.rs` | submodule list + `pub(super) use` of each `draw_*` |
-| `modals/deals.rs` | deals modal + support-slot modal |
-| `modals/charts.rs` | charts modal |
-| `modals/marketing.rs` | marketing release/campaign modal |
-| `modals/file.rs` | save/load modal |
-| `modals/pickers.rs` | venue, pressing-run, region pickers |
-
-Keep `render/mod.rs` calling `modals::draw_*` (re-exports). Shared helpers
-stay in `render/mod.rs` (`centered_rect`, `ACCENT`, …). Leaf draw fns may
-use `pub(crate)` so they can be re-exported (same nested-module visibility
-pattern as T5/T9).
-
-**Acceptance:** no monolithic `render/modals.rs`; each leaf file under ~250
-lines preferred; `cargo test` / clippy / fmt clean; no visual redesign.
-
----
-
-### T11 — Cycle close
-
-**Do:**
-
-1. Confirm board: all required tasks ✅ (incl. T12), claims consistent with git history.
-2. Paste a short **line-count table** (production files only) under Notes
-   below.
-3. Add 2–4 lines under CHANGELOG **Internal** (unreleased / 0.5.1) listing
-   the structural split — no fake player-facing notes.
-4. Optionally move this file to `docs/archive/HANDOFF-v0.5.1-structure.md`
-   when the human opens the Musician cycle (human trigger).
-
-**Acceptance:** `cargo test` / clippy / fmt clean on `main`; HANDOFF board
-all required ✅.
+## Task acceptance (one line each; details in the design doc)
+
+- **L1:** four bars move per §A weekly tick; energy unread anywhere under
+  `src/` (field intact); laze/break rework in; guards swapped; old saves load.
+- **L2:** songwriting uses creativity + happiness multiplier; consumption
+  only on streak ≥ 3 or stress > 50; `writing_streak` resets on any
+  non-writing action.
+- **L3:** every gig/tour resolves per-show (5/tour-week) with reception +
+  box office + momentum; `last_tour_report` populated; tour money within
+  ballpark of 0.5.1 in the sim lab; great shows feed creativity.
+- **L4:** report modal readable for a 20-show tour; main panel shows the
+  four bars (energy gone from UI); no other visual redesign.
+- **L5:** floors/grace/ramp/comeback exactly per §C tables; charting and
+  establishment rules freeze the idle clock; `peak_chart_position`
+  recorded at launch resolution; worked example (fame 15 → 0 at week 7)
+  encoded as a test.
+- **L6:** cuts only when signed + un-singled album tracks + quiet; caps
+  respected; the cut is a real release (chartable, royalties, activity).
+- **L7:** post-launch marketing measurably moves catalog sales in a test;
+  tail decays per §D; lifetime income sane in sim lab.
+- **L8:** zero incident content hardcoded in Rust; conditions + weights +
+  effect ranges honored; DrugOffer absent; cadence per §F; determinism
+  tests green.
+- **L9:** hitting the thresholds logs the milestone once, sets the flag,
+  game continues; death/broke endings unchanged.
+- **L10:** every [tune] value either confirmed or adjusted with a Notes
+  line; sweep comparing 0.5.1 vs 0.6 fame/income trajectories pasted below.
+- **L11:** board all ✅, CHANGELOG 0.6.0 written (player-facing notes this
+  time — it's a feature cycle), version bumped, PR opened to `main`.
 
 ---
 
@@ -499,16 +170,15 @@ all required ✅.
 
 | Path | Who may touch |
 |------|----------------|
-| `src/game/mod.rs` | T1 (tests wiring), T2, T3, T6 (`mod` line only), T4/T5/T7 (`mod` / `pub use` lines only) — **serialize** via prereqs + rebase |
-| `src/game/world.rs` → `world/` | T4 then T7 only |
-| `src/game/actions.rs` → `actions/` | T5 only |
-| `src/game/turn.rs` | T6 primarily; T8 imports only |
-| `src/ui/app.rs` | T9 |
-| `src/ui/render.rs` → `render/**` | T10; then T12 owns only `render/modals*` |
-| `HANDOFF.md` board rows | **Every agent** for their claim/complete only — do not rewrite other tasks’ details |
-| `FUTURE.md` | nobody this cycle |
-| `data/**` | nobody this cycle |
-| `tests/fixtures/**` | nobody this cycle |
+| `src/game/turn.rs` | L5 primarily; L1/L6/L9 one call-site line each (serialized by prereqs where listed) |
+| `src/game/core.rs` | L2, L3, L9 — field + accessor lines only |
+| `src/game/constants.rs` | L1 (stat consts), L5 (fame consts), L7 (tail consts) — separate blocks, rebase |
+| `src/game/economy.rs` | L7 (catalog tail); L5 (chart write-back line only) |
+| `src/game/music.rs` | L5 (`peak_chart_position`), L6 (cut tracking) — serialized by prereq |
+| `src/ui/**` | L4 only |
+| `data/**` | L8 only |
+| `docs/DESIGN-v0.6-life-cycle.md` | nobody edits mid-cycle; design changes go through the human |
+| `FUTURE.md`, `tests/fixtures/**` | nobody |
 
 ---
 
@@ -518,51 +188,16 @@ all required ✅.
 cargo test
 cargo clippy --all-targets -- -D warnings
 cargo fmt --check
-# determinism / save still in the suite:
+# contracts:
 cargo test same_seed_and_same_choices_replay_the_same_career
 cargo test saves_from_v0_4_still_load
 cargo test worldgen_is_reproducible_per_seed
-```
-
-After T7:
-
-```bash
-cargo test scene_
-cargo test chart_
-cargo test independent_labels_scout
+# balance lab (ignored sweeps, run locally when tuning):
+cargo test --release -- --ignored
 ```
 
 ---
 
 ## Notes (agents append one-liners here)
 
-_Example:_  
-`2026-07-13 T5 claimed by grok-struct-1 on struct/t4-genre`
-
-- 2026-07-13 T4 done by grok-struct-t4 on `struct/t4-genre`: canonical path `crate::game::genre::MusicGenre`; no world re-export; `random`/`random_trending` are `pub(crate)`.
-- 2026-07-13 T9 done by antigravity on `struct/t4-genre`.
-- 2026-07-13 **Policy:** single shared branch `struct/t4-genre` for the whole structure cycle — no per-task branches. Abandoned names like `struct/t1-tests-out` must not be used; rebase any stray work onto `struct/t4-genre`.
-- 2026-07-13 T5 done by grok-struct-t5 on `struct/t4-genre`: `actions.rs` → `actions/{mod,studio,live,business,rest}.rs`; action methods use `pub(in crate::game)` so nested modules stay visible to game tests/turn.
-- 2026-07-13 T6 done by pier-t6 on `struct/t4-genre`: `apply_random_event` + `apply_historical_event` → `events_apply.rs` as `pub(super) impl Game`; `turn.rs` down from 538 to 285 lines; `mod events_apply;` in `mod.rs`. ⚠ cargo test / git push blocked by env (SSL + index-lock); code structure verified manually.
-- 2026-07-13 T10 done by antigravity on `struct/t4-genre`: `render.rs` → `render/{mod,setup,layout,panels,modals,game_over}.rs`; shared helpers (centered_rect, gauge, scale_color, format_population) in `render/mod.rs`; `pub(crate)` for ACCENT const.
-- 2026-07-13 T12 claimed+done by grok-struct-t12 on `struct/t4-genre`: `render/modals.rs` → `modals/{mod,deals,charts,marketing,file,pickers}.rs` with re-exports; parallel-safe with T7.
-- 2026-07-13 T7 done by grok-struct-t7 on `struct/t4-genre`: `world.rs` → `world/{mod,scene,charts,deals,venues}.rs`; public API re-exported from `world/mod.rs`; tests stay under `world::tests`. No impact on T2 (disjoint owns).
-- 2026-07-13 T2 done by pier-t2 (extract) + grok-t2-polish (land): 40 game tuning consts → `src/game/constants.rs`; data constants re-exported; `pub use constants::{PRESSING_TIERS, BREAK_WEEKS}`; uniform `use …constants::{self, *}` (or `use …constants` where only path form); clippy clean; committed to `struct/t4-genre`.
-- 2026-07-13 T3 done by antigravity on `struct/t4-genre`: `Game`, `GameAction`, `SupportTourOffer`, and core lifecycle/save/load logic moved to `core.rs`; `mod.rs` reduced to submodule definitions and re-exports; clippy clean.
-- 2026-07-13 T8 done by grok-struct-t8 on `struct/t4-genre`: `rng.rs` holds splitmix64 mixer + `world_rng_for_week` / `action_rng_for_week` + `Game::action_rng*`; salts stay in `constants.rs`; turn uses world builder. Determinism tests green.
-- 2026-07-14 T11 done by claude-t11 on `struct/t4-genre`. **Cycle close, cut as 0.5.1.** Board audit: T1–T10 + T12 all ✅ with real commit SHAs (verified via `git cat-file`); T8 (optional) done. Full suite green: `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test` → 42 passed / 2 ignored (same names as the 0.5.0 baseline). CHANGELOG 0.5.1 Internal added; `Cargo.toml`/`Cargo.lock` bumped 0.5.0 → 0.5.1. Archive of this file deferred to the human Musician-cycle trigger (step 4).
-
-### T11 line-count report (production `.rs`; `tests/` and `sim.rs` excluded)
-
-Monolith → package, **start-of-cycle → now** (lines):
-
-| Was | Lines | Now |
-|-----|-------|-----|
-| `game/mod.rs` | 1060 → **27** | shell; + `core` 189, `constants` 97, `rng` 67, `genre` 85, `events_apply` 266, `tests/**` |
-| `game/world.rs` | 1090 → `world/**` | `mod` 486, `scene` 253, `deals` 186, `charts` 68, `venues` 49 |
-| `game/actions.rs` | 719 → `actions/**` | `studio` 279, `live` 244, `business` 162, `rest` 41, `mod` 41 |
-| `game/turn.rs` | 537 → **281** | event outcomes → `events_apply` 266 |
-| `ui/render.rs` | 1052 → `render/**` | `panels` 319, `setup` 101, `mod` 84, `game_over` 67, `layout` 33, `modals/{pickers 222, deals 146, marketing 77, charts 60, file 44, mod 15}` |
-| `ui/app.rs` | 986 → **420** | + `input/{pickers 170, main 127, setup 120, deals 82, marketing 72, file 46, mod 8}` |
-
-Largest production file now: `game/world/mod.rs` at **486** (< 500 hard cap). Shell modules meet targets: `game/mod.rs` 27 (≪80), `actions/mod.rs` 41 (≪80), `ui/render/modals/mod.rs` 15, `ui/input/mod.rs` 8. All production `.rs` ≤ 486 lines.
+_Format:_ `YYYY-MM-DD L# <claimed|done|unclaimed> by <agent> — <one line>`

--- a/docs/DESIGN-v0.6-life-cycle.md
+++ b/docs/DESIGN-v0.6-life-cycle.md
@@ -1,0 +1,327 @@
+# Design — The Life Cycle (v0.6)
+
+> Bars, shows, fame gravity, and data-driven incidents. This document is the
+> **decided design** for the v0.6 feature cycle, agreed in discussion on
+> 2026-07-14. The task board lives in `HANDOFF.md`. FUTURE.md (Musician,
+> relationships, solo/band) stays the north star for the cycle *after* this
+> one; where this doc overlaps FUTURE §9 (happiness), this doc wins.
+>
+> **Deferred explicitly:** the drug/addiction system (FUTURE §9.1) is *not*
+> in this cycle. The `drug_addiction` / `alcohol_addiction` fields stay
+> serialized but dormant. Vacations picker (§9.3) and the Manager (§9.4)
+> also wait.
+
+Numbers marked **[tune]** are starting values to be validated in the
+`sim.rs` balance lab, not contract. Everything else is decided design.
+
+---
+
+## §A — The four bars
+
+The original 1989 game ran on happiness, creativity, alertness, and health.
+We keep that engine with **stress in the alertness slot** — stress is the
+better primitive: it is the *cause*, the other bars are the *effects*.
+
+| Bar | Range | Role |
+|-----|-------|------|
+| **Health** | 0–100 | Survival. 0 = death (unchanged game over). |
+| **Stress** | 0–100 | The pressure valve. Work raises it; it drains everything else. |
+| **Happiness** | 0–100 | The career's mood. Fed by success, drained by stress. |
+| **Creativity** | 0–100 | The tank songs are written from. Fed by great shows and rest, drained by stress and overwork. |
+
+**Energy is removed as a mechanic.** The serialized `energy` field stays on
+`Player` (never rename serialized fields) but nothing reads it. Action
+guards that checked energy now check stress/health instead.
+
+### The loop
+
+Work hard → stress up → happiness and creativity sag → shows and songs get
+worse… **unless the work is landing**, in which case great shows and
+charting records refill the very bars the grind drains. Success sustains
+the machine; failure while grinding spirals. That is the game.
+
+### Weekly tick (runs in the turn pipeline)
+
+- **Stress:** passive release **−3/week** [tune]. Raised by actions (below)
+  and by bad outcomes: a flop **+15**, broke (money < 0) **+5/week** [tune].
+- **Happiness:** drains **−(stress / 25) per week** (0 to −4) [tune].
+  Gains: chart entry **+12 at #1 scaling to +3 at #40** [tune]; a tour that
+  went very well (see §B) **+8**; first-time milestones (first single,
+  first album, first tour) **+10** each, one-shot.
+- **Creativity:** while stress > 40, drains **−(stress − 40) / 20 per
+  week** (0 to −3) [tune]. Gains: each *great* show **+2**, each
+  *transcendent* show **+3** (§B verdicts); a well-received tour **+5**;
+  a lazing week **+3**; inspiration incidents (§F).
+- **Health:** existing stress-driven decay stays (`stress / 20` per week —
+  the dormant addiction terms contribute 0). **Touring wears harder**:
+  **−4 per tour week** [tune], replacing today's 15 %-chance-of-−10.
+  **Excessive lazing** also wears: lazing streak > 4 consecutive weeks →
+  **−1/week** [tune] — turtling is safe for months, not years.
+
+### Action costs (energy guards → stress economy)
+
+| Action | Old energy rule | New rule |
+|--------|-----------------|----------|
+| Play gig | needs 30, costs 30 | blocked if stress ≥ 85 or health < 20; **+8 stress** [tune] |
+| Tour | needs 40, costs 40, +30 stress | blocked if stress ≥ 70 or health < 30; **+12 stress per tour week** [tune] |
+| Write song | costs 20 | blocked if stress ≥ 90; **+5 stress** [tune] |
+| Record | costs 15 | blocked if stress ≥ 90; **+8 stress** [tune] |
+| Laze | +20 energy, −10 stress | **−15 stress**, +3 creativity; health wear on long streaks (above) |
+| Take a break | full reset | stress → 0, +10 happiness, +10 creativity, +30 health (as today) |
+| Doctor | +20 health | unchanged |
+
+### Writing consumes creativity — but only when forced
+
+Writing does **not** drain creativity in the healthy case. It drains when:
+
+- **Writing too much:** 3rd and every subsequent *consecutive* writing week
+  → **−5 creativity/week** [tune] (track a `writing_streak`, reset by any
+  non-writing action).
+- **Writing under stress:** stress > 50 at the moment of writing →
+  **−(stress − 50) / 5 creativity** [tune].
+
+So the natural rhythm is the original's: write → tour it → the shows
+refill the tank → write again. Grinding out an album in one stressed
+sitting empties the well.
+
+### Quality formulas
+
+- **Songwriting** = base 30 + **creativity / 4** (0–25, replaces the old
+  energy/stress bonus) + skill/genre terms as today + random variation,
+  all × **happiness multiplier `0.8 + happiness/500`** (0.8–1.0, from
+  FUTURE §9.2).
+- **Recording** = base 30 + band-skill term as today + condition penalty
+  if stress > 70 (−10) [tune], × happiness multiplier.
+
+---
+
+## §B — Per-show analysis (gigs and tours)
+
+Every concert — one-off gig or tour stop — resolves **individually** with
+two numbers. **5 shows per tour week** (decided). A 3-week tour = 15 shows.
+
+### Reception (0–100): how the crowd took it
+
+```
+reception = band_base                    # dominant term
+          + condition                    # stress/health penalties
+          + era_fit                      # genre-era modifier, scaled ±10
+          + variance                     # rng, −10..+10
+          + creativity_upside            # rng, 0..(creativity/5)
+```
+
+- `band_base` = **0.7 × average member skill + 0.3 ×
+  reputation.live_performance** [tune]. This is the dominant term by
+  design: **a band with 100 % rating and 0 creativity can still be
+  exceptional.** Creativity is *never* a multiplier — it widens the upside
+  tail (0 to +20 at creativity 100), making transcendent nights more
+  likely. A tight, uninspired band is reliably excellent; an inspired one
+  catches fire.
+- `condition`: stress > 70 → −10; health < 40 → −10 [tune].
+
+**Verdicts:** < 40 *rough night* · 40–69 *solid* · 70–84 *great* ·
+≥ 85 *transcendent*. Great and transcendent shows feed creativity (§A);
+transcendent also +2 happiness on the spot.
+
+### Box office: tickets and money
+
+- One-off gig: existing venue attendance model
+  (`(fame+10)/(prestige+10)` ratio × capacity) becomes the per-show base,
+  **× momentum** (below). Earnings per the existing payment formula.
+- Tour stop: venue is synthesized per show from the region (capacity drawn
+  from population/economic strength [tune]); attendance from fame +
+  regional fame × momentum; gross per the existing touring economics,
+  paid per show. Total tour money should land in today's ballpark —
+  validate in the sim lab, it's a redistribution, not a buff.
+
+### Momentum: word of mouth inside a tour
+
+A rolling multiplier **0.85–1.15** [tune], starts at 1.0, nudged up by
+each great/transcendent night and down by each rough one. A hot streak
+sells the back half of the tour; a mid-tour disaster deflates it. This is
+what makes the per-day report worth *reading* — the nights are a story,
+not independent rolls.
+
+### The tour report
+
+A new modal (existing `render/modals/` pattern) showing one row per show:
+**week/day, city, venue, reception verdict, attendance/capacity, take** —
+plus a summary line (average reception, total gross, fame gained). Stored
+on `Game` as `last_tour_report` (serde default empty; old saves fine).
+One-off gigs produce the same row inline in the log and the report holds
+the last gig too.
+
+**Tour verdicts** (drives §A happiness/creativity): average reception
+≥ 70 → *"the tour went very well"* → +8 happiness, +5 creativity. Fame
+gains stay per-show, small, capped by the existing `live_fame_cap`.
+
+---
+
+## §C — Fame gravity (fully decided)
+
+### New state
+
+- `Band::peak_fame: u8` — highest fame ever reached. Serde default 0; on
+  load, lift to current fame.
+- `Release::peak_chart_position: Option<u8>` — best chart position ever.
+  Serde default None. **A "hit" = a release that charted at all** (i.e.
+  `peak_chart_position.is_some()`).
+
+### Floors — earned at peak, permanent, by 15s
+
+| Peak fame reached | Floor (never fall below) |
+|---|---|
+| under 30 | 0 |
+| 30 | 10 |
+| 45 | 15 |
+| 60 | 30 |
+| 75 | 45 |
+| 90 | 60 |
+| 95+ | 70 |
+| 95+ **and** ≥ 10 hit albums/singles | 75 |
+
+### Grace — quiet weeks before decay, by current fame
+
+| Current fame | Grace |
+|---|---|
+| 0–14 | 2 weeks |
+| 15–29 | 4 weeks |
+| 30–49 | 8 weeks |
+| 50–74 | 13 weeks (3 months) |
+| 75–89 | 26 weeks (6 months) |
+| 90–94 | 39 weeks (9 months) |
+| 95+ | 52 weeks (1 year) |
+
+### The ramp
+
+After grace expires: **−1 the first week, −2, −3, −4, then −5/week**
+flat from there. Evaluated weekly against *current* fame's tier. Stops
+dead at the floor. Any activity resets the idle streak (and thus the
+ramp) to zero. Worked check (decided example): fame 15, fully idle —
+nothing weeks 1–2, then 1+2+3+4+5 → fame 0 at week 7.
+
+### Comeback
+
+While `fame < peak_fame`, **all fame gains ×2** [only the multiplier is
+tune-able], normal beyond. Reclaiming ground is easier than conquering it.
+
+### Activity — three ways to be "in the picture" (idle streak stays 0)
+
+1. **Public action** — gig, tour, support slot, or a release in its
+   4-week launch window (today's rule).
+2. **On the charts** — while any player release is on the charts, the
+   idle clock does not run. Immunity duration is emergent: a #1 album
+   protects you for its whole run, a #38 single buys two weeks.
+3. **The establishment rule** — at fame ≥ 60, an album or single released
+   in the past 52 weeks counts as activity. Below 60, it doesn't — small
+   acts must keep showing up.
+
+### Label single-cuts
+
+If signed, with an album that has un-singled tracks, and the band has
+gone quiet [tune: idle ≥ 3 weeks, ~10 % weekly chance on the action
+stream, max 2 cuts per album, ≥ 6 weeks since any release]: **the label
+releases a single from the album on its own volition.** It is a real
+release — label pressing, label promo, chartable, royalties at deal
+rate — so it feeds activity rules 1–3 automatically. Log makes clear it
+wasn't your call: *"📀 Without asking, {label} pulls '{song}' off the
+album as a single."* (Relationship friction hook for the Musician cycle.)
+
+---
+
+## §D — Sales tail
+
+Today's long tail is `initial_score / (1 + weeks_since_window)` with an
+extra ÷5 — the first tail week sells ~7 % of launch and a modest record
+is dead in 3 months. Also, post-launch marketing is recomputed but
+**never read** — campaigns started after the launch window burn money.
+
+Changes:
+
+- **Gentler curve:** divisor grows at a third of the rate —
+  `1 + weeks_since / 3` [tune].
+- **Living tail:** ongoing score =
+  `(initial_score + current_marketing × 1.8 + fame × 0.3) / divisor`
+  [tune] — post-launch marketing now works, and a famous act's catalog
+  keeps selling (pairs with §C: charting protects fame, fame sells
+  catalog).
+- Keep the pressed-copies bound and the trickle cutoff; retune the unit
+  divisor in the sim lab so total lifetime income lands sane.
+
+---
+
+## §E — No ending at the top
+
+Reaching `ROCKSTAR_FAME_THRESHOLD` + album count **no longer ends the
+game.** It becomes a one-time milestone: celebratory log + a
+`rockstar_achieved: bool` on `Game` (serde default false; set once, never
+unset). Death (health 0) and broke-and-unknown remain the only endings.
+Post-peak decline, comebacks, and the long second act are now playable —
+that's what §C's floors and comeback multiplier are for.
+
+---
+
+## §F — Data-driven incidents
+
+**More random incidents, defined in JSON, outside the Rust source.**
+New file `data/incidents.json`, loaded through `data_loader.rs` like
+`markets.json` / `record_labels.json`.
+
+### Schema
+
+```json
+{
+  "incidents": [
+    {
+      "id": "backstage_party",
+      "category": "social",
+      "weight": 3,
+      "conditions": { "min_fame": 10, "max_fame": null, "on_tour": null, "signed": null },
+      "effects": {
+        "stress":     [-15, -5],
+        "happiness":  [5, 15],
+        "creativity": [0, 5],
+        "health":     [-5, 0],
+        "money":      [0, 0],
+        "fame":       [0, 0]
+      },
+      "message": "🎉 A legendary after-party — the whole scene was there."
+    }
+  ]
+}
+```
+
+- `weight` = relative selection weight among incidents whose `conditions`
+  match the current game state. `effects` are inclusive ranges rolled on
+  the action stream; zero-range fields may be omitted.
+- The hardcoded `RandomEvent` enum arms (equipment, media, health, money,
+  industry, band member) migrate into the JSON. `DrugOffer` is **dropped**
+  from the pool this cycle (system deferred). `EventManager`'s serialized
+  shape (`last_event_week`) is unchanged.
+- **Cadence up** ("more random incidents"): eligible every week (was
+  every 2), **35 % chance** [tune] (was 30 % every other week).
+- New content to write alongside the migration: parties, press moments,
+  gear failures, venue mishaps, fan encounters, industry gossip —
+  incidents that move the four bars, since the bars are now the game.
+- **Scope note:** this cycle externalizes *incidents*. The general log
+  message catalog (gig lines, deal lines, …) staying in code is accepted
+  for now; a follow-up cycle can externalize messages wholesale.
+
+---
+
+## §G — Engineering constraints (unchanged law)
+
+- **Determinism:** all new rolls (per-show, incidents, label cuts) draw
+  from the existing seeded streams — per-show rolls on the **action
+  stream** inside the action that caused them, world evolution stays on
+  the world stream. The determinism tests must keep passing (same-version
+  replay is the contract; this cycle may change what a seed produces
+  vs 0.5, that's fine).
+- **Saves:** every new field `#[serde(default)]` (or default-fn). Never
+  rename serialized fields. `tests/fixtures/pre-0.5.sav` must keep
+  loading. `energy` and the addiction fields stay serialized, dormant.
+- **Quality gates:** `cargo test`, `cargo clippy --all-targets -- -D
+  warnings`, `cargo fmt --check` — green on every task completion.
+- **Balance validation:** the `sim.rs` bot harness is the referee for
+  every [tune] value — add sweeps comparing income/fame trajectories
+  before declaring a number final.

--- a/docs/DESIGN-v0.6-life-cycle.md
+++ b/docs/DESIGN-v0.6-life-cycle.md
@@ -107,15 +107,16 @@ reception = band_base                    # dominant term
           + condition                    # stress/health penalties
           + era_fit                      # genre-era modifier, scaled ±10
           + variance                     # rng, −10..+10
-          + creativity_upside            # rng, 0..(creativity/5)
+          + creativity_upside            # rng, 0..=creativity/5 (inclusive; 0 at creativity 0)
 ```
 
 - `band_base` = **0.7 × average member skill + 0.3 ×
   reputation.live_performance** [tune]. This is the dominant term by
   design: **a band with 100 % rating and 0 creativity can still be
   exceptional.** Creativity is *never* a multiplier — it widens the upside
-  tail (0 to +20 at creativity 100), making transcendent nights more
-  likely. A tight, uninspired band is reliably excellent; an inspired one
+  tail (an inclusive roll of 0 to +20 at creativity 100; exactly 0 at
+  creativity 0, never an empty/panicking range), making transcendent
+  nights more likely. A tight, uninspired band is reliably excellent; an inspired one
   catches fire.
 - `condition`: stress > 70 → −10; health < 40 → −10 [tune].
 
@@ -136,9 +137,11 @@ transcendent also +2 happiness on the spot.
 
 ### Momentum: word of mouth inside a tour
 
-A rolling multiplier **0.85–1.15** [tune], starts at 1.0, nudged up by
-each great/transcendent night and down by each rough one. A hot streak
-sells the back half of the tour; a mid-tour disaster deflates it. This is
+A rolling multiplier, starts at 1.0. After each show, apply the delta
+for its verdict, *then* clamp to **0.85–1.15**. Deltas [tune]:
+transcendent **+0.05**, great **+0.03**, solid **0**, rough **−0.05**.
+A hot streak sells the back half of the tour; a mid-tour disaster
+deflates it. This is
 what makes the per-day report worth *reading* — the nights are a story,
 not independent rolls.
 
@@ -184,8 +187,8 @@ gains stay per-show, small, capped by the existing `live_fame_cap`.
 
 | Current fame | Grace |
 |---|---|
-| 0–14 | 2 weeks |
-| 15–29 | 4 weeks |
+| 0–15 | 2 weeks |
+| 16–29 | 4 weeks |
 | 30–49 | 8 weeks |
 | 50–74 | 13 weeks (3 months) |
 | 75–89 | 26 weeks (6 months) |
@@ -197,8 +200,9 @@ gains stay per-show, small, capped by the existing `live_fame_cap`.
 After grace expires: **−1 the first week, −2, −3, −4, then −5/week**
 flat from there. Evaluated weekly against *current* fame's tier. Stops
 dead at the floor. Any activity resets the idle streak (and thus the
-ramp) to zero. Worked check (decided example): fame 15, fully idle —
-nothing weeks 1–2, then 1+2+3+4+5 → fame 0 at week 7.
+ramp) to zero. Worked check (decided example — hence the 0–15 bottom
+tier, "till 15" inclusive): fame 15, fully idle — nothing weeks 1–2,
+then −1, −2, −3, −4, −5 on weeks 3–7 → fame 0 at week 7.
 
 ### Comeback
 
@@ -266,6 +270,16 @@ that's what §C's floors and comeback multiplier are for.
 **More random incidents, defined in JSON, outside the Rust source.**
 New file `data/incidents.json`, loaded through `data_loader.rs` like
 `markets.json` / `record_labels.json`.
+
+**Loader contract** (L8 implements; nothing exists in `data_loader.rs`
+yet): `GameDataFiles` gains an `incidents_data: IncidentsData` field,
+deserialized from `data/incidents.json` at startup alongside the other
+JSON files, with load-time validation — non-empty incident list, every
+`weight` ≥ 1, every effect range `[lo, hi]` with `lo ≤ hi`, unique `id`s
+— failing fast with a clear error like the existing loaders. Selection
+goes through an accessor (e.g. `eligible_incidents(&GameState) ->
+Vec<&Incident>`) that filters on `conditions`; the weighted pick itself
+rolls on the action stream in `events.rs`.
 
 ### Schema
 

--- a/docs/archive/HANDOFF-v0.5.1-structure.md
+++ b/docs/archive/HANDOFF-v0.5.1-structure.md
@@ -1,6 +1,11 @@
+> **Archived record (v0.5.1) — historical reference only.** This cycle is
+> complete; do not claim tasks or follow the branch/claim protocol below.
+> The active coordination surface is `HANDOFF.md` at the repo root
+> (v0.6 Life Cycle).
+
 # Rocker — Structure Hardening Handoff (v0.5.1)
 
-> **Active cycle.** Pure structural refactor so the next feature cycle
+> **Cycle status at close.** Pure structural refactor so the next feature cycle
 > (Musician / FUTURE.md §1–§6) lands in small, owned files. **No gameplay
 > behavior changes.** No formula tuning. No Musician implementation yet.
 >
@@ -550,7 +555,7 @@ _Example:_
 - 2026-07-13 T2 done by pier-t2 (extract) + grok-t2-polish (land): 40 game tuning consts → `src/game/constants.rs`; data constants re-exported; `pub use constants::{PRESSING_TIERS, BREAK_WEEKS}`; uniform `use …constants::{self, *}` (or `use …constants` where only path form); clippy clean; committed to `struct/t4-genre`.
 - 2026-07-13 T3 done by antigravity on `struct/t4-genre`: `Game`, `GameAction`, `SupportTourOffer`, and core lifecycle/save/load logic moved to `core.rs`; `mod.rs` reduced to submodule definitions and re-exports; clippy clean.
 - 2026-07-13 T8 done by grok-struct-t8 on `struct/t4-genre`: `rng.rs` holds splitmix64 mixer + `world_rng_for_week` / `action_rng_for_week` + `Game::action_rng*`; salts stay in `constants.rs`; turn uses world builder. Determinism tests green.
-- 2026-07-14 T11 done by claude-t11 on `struct/t4-genre`. **Cycle close, cut as 0.5.1.** Board audit: T1–T10 + T12 all ✅ with real commit SHAs (verified via `git cat-file`); T8 (optional) done. Full suite green: `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test` → 42 passed / 2 ignored (same names as the 0.5.0 baseline). CHANGELOG 0.5.1 Internal added; `Cargo.toml`/`Cargo.lock` bumped 0.5.0 → 0.5.1. Archive of this file deferred to the human Musician-cycle trigger (step 4).
+- 2026-07-14 T11 done by claude-t11 on `struct/t4-genre`. **Cycle close, cut as 0.5.1.** Board audit: T1–T10 + T12 all ✅ with real commit SHAs (verified via `git cat-file`); T8 (optional) done. Full suite green: `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test` → 42 passed / 2 ignored (same names as the 0.5.0 baseline). CHANGELOG 0.5.1 Internal added; `Cargo.toml`/`Cargo.lock` bumped 0.5.0 → 0.5.1. At the time of this note, archiving was deferred to the human next-cycle trigger (step 4) — since done; this file is that archive.
 
 ### T11 line-count report (production `.rs`; `tests/` and `sim.rs` excluded)
 

--- a/docs/archive/HANDOFF-v0.5.1-structure.md
+++ b/docs/archive/HANDOFF-v0.5.1-structure.md
@@ -1,0 +1,568 @@
+# Rocker — Structure Hardening Handoff (v0.5.1)
+
+> **Active cycle.** Pure structural refactor so the next feature cycle
+> (Musician / FUTURE.md §1–§6) lands in small, owned files. **No gameplay
+> behavior changes.** No formula tuning. No Musician implementation yet.
+>
+> Prior cycle: `docs/archive/HANDOFF-v0.5-cycle.md` · What shipped: `CHANGELOG.md`
+> · Design north star (later): `FUTURE.md`
+
+Baseline on start of cycle: **0.5.0**, `cargo test` → **42 passed, 2 ignored**,
+clippy clean, `thread_rng` gone, `src/game/mod.rs` ~1 060 lines of which
+~750 are tests.
+
+---
+
+## How agents claim work
+
+This handoff is the **single coordination surface**. Do not start a task
+that is already claimed or whose prerequisites are not ✅.
+
+### One branch for the whole cycle
+
+**All structure work lands on `struct/t4-genre`.** Do not open
+`struct/t1-…`, `struct/t5-…`, or any other task branch. Multi-branch
+parallelism caused rebase pain and split history; coordination is the
+**board + exclusive Owns**, not git branches.
+
+```text
+git fetch origin
+git checkout struct/t4-genre
+git pull --rebase origin struct/t4-genre   # always before claim / before push
+# … do one claimed task …
+git push origin struct/t4-genre
+```
+
+If `pull --rebase` conflicts in files you do **not** own, stop and
+unclaim — do not “fix” another agent’s WIP.
+
+### Claim protocol (mandatory)
+
+1. **On `struct/t4-genre`**, up to date with `origin` (see above).
+2. **Read this whole file**, then the task section for the ID you want.
+3. **Prerequisites:** every ID in `Prereqs` must be `✅ done` (or `—`).
+4. **Claim atomically** — edit the Task board row in the **same commit**
+   that starts the work (or a tiny commit immediately before code):
+   - `Status`: `⬜ open` → `🔒 claimed`
+   - `Claimed by`: short agent/session id (e.g. `claude-a3f2`, `grok-struct-1`)
+   - `Branch` column: always `struct/t4-genre` (shared; do not invent a name)
+5. **While working**, you own every path listed under **Owns**. Do not
+   edit another open/`🔒 claimed` task’s owned files. If you must touch
+   shared wiring (`src/game/mod.rs` module list, `src/ui/mod.rs`), keep
+   the diff to the minimum `mod` / `pub use` lines.
+6. **Done means green**, then update the board and **push the same branch**:
+   - `Status`: `🔒 claimed` → `✅ done`
+   - Fill `Done` with the commit short SHA that completed the task
+   - Leave `Claimed by` as historical record
+7. **Unclaim** if you abort: set `Status` back to `⬜ open`, clear
+   `Claimed by`, and say why in one line under Notes.
+
+### Status legend
+
+| Mark | Meaning |
+|------|---------|
+| `⬜ open` | Available if prereqs are done |
+| `🔒 claimed` | An agent is actively working it — **do not take** |
+| `✅ done` | Merged / complete; safe as a prerequisite |
+| `⏸ blocked` | Waiting on human decision (should be rare this cycle) |
+
+### Ground rules (every agent)
+
+- **Pure moves only.** No behavior changes, balance tweaks, log-line
+  rewrites, or “while I’m here” formula fixes. If a test fails after a
+  move, you restored visibility wrong — fix the move, don’t “fix” the game.
+- **Verify before claiming done:**
+  ```text
+  cargo test
+  cargo clippy --all-targets -- -D warnings
+  cargo fmt --check
+  ```
+  Same test **names** and **count** (42 + 2 ignored) unless the task
+  explicitly relocates tests (names must still match).
+- **Serde / saves:** do not rename serialized fields. Re-exports are fine;
+  on-disk shape is sacred (`tests/fixtures/pre-0.5.sav` must keep loading).
+- **RNG draw order is sacred.** Moving code must not reorder
+  `gen_*` calls on a stream. The determinism tests
+  (`same_seed_and_same_choices_replay_the_same_career`,
+  `seeded_worlds_are_reproducible_in_the_harness`,
+  `worldgen_is_reproducible_per_seed`) are the contract — if they fail,
+  you reshuffled draws; undo.
+- **Visibility:** prefer `pub(super)` / `pub(crate)` over `pub`. Integration
+  tests are **not** the goal this cycle; keep unit-test access via
+  `#[cfg(test)]` modules under `src/game/`.
+- **One shared branch:** `struct/t4-genre` only. Commit message prefix:
+  `struct(T#): <short description>`. One open PR from this branch to
+  `main` when the cycle closes (or whenever the human merges); agents
+  push commits, they do not open parallel task PRs.
+- **Update this file** when claiming and when completing, on the same
+  branch as the code.
+
+### Do-not-undo (still in force from v0.5)
+
+- World + action RNG injection from `world_seed` — never reintroduce
+  `thread_rng` under `src/`.
+- Live fame double-cap, idle decay, pressing/unit economics, label marketing
+  ownership, news-from-state, `MusicGenre` as the single genre enum.
+- Support slots remain deliberately uncapped by catalog fame.
+
+### Out of scope this cycle
+
+- FUTURE.md Musician / abilities / personality
+- Decade pacing, event-fame audit, tour bots, difficulty modes
+- New features, UI chrome, balance passes
+
+Those wait for a **Musician cycle handoff** after this board is all ✅.
+
+---
+
+## Task board (source of truth)
+
+**How to read prereqs:** `—` = none (start when ready). Multiple IDs =
+all must be ✅. Tasks with **disjoint Owns** and satisfied prereqs may
+run **in parallel on the same branch** — never via extra branches.
+
+| ID | Task | Size | Prereqs | Owns (exclusive) | Status | Claimed by | Branch | Done |
+|----|------|------|---------|------------------|--------|------------|--------|------|
+| **T1** | Extract `game` unit tests out of `mod.rs` into `src/game/tests/` | M | — | `src/game/mod.rs` *(tests module only + `mod tests` wiring)*, **new** `src/game/tests/**` | ✅ done | claude-t1 | struct/t4-genre | 78f93a5 |
+| **T2** | Extract tuning knobs → `src/game/constants.rs` | S | T1 | `src/game/constants.rs` *(new)*, `src/game/mod.rs` *(const block → re-export)*, imports in modules that referenced parent consts | ✅ done | pier-t2 / grok-t2-polish | struct/t4-genre | 40aadef |
+| **T3** | Extract `Game` / `GameAction` / lifecycle → `src/game/core.rs`; thin `mod.rs` | S | T2 | `src/game/core.rs` *(new)*, `src/game/mod.rs` *(shell)*, `src/game/tests/**` *(paths/`use` only if needed)* | ✅ done | antigravity | struct/t4-genre | ea15990 |
+| **T4** | Extract `MusicGenre` → `src/game/genre.rs` | S | — | `src/game/genre.rs` *(new)*, `src/game/world.rs` *(remove genre)*, all `use` sites of `MusicGenre` | ✅ done | grok-struct-t4 | struct/t4-genre | 860fb6f |
+| **T5** | Split `actions.rs` → `actions/{mod,studio,live,business,rest}.rs` | M | — | `src/game/actions.rs` → `src/game/actions/**` only | ✅ done | grok-struct-t5 | struct/t4-genre | b601eab |
+| **T6** | Split event *outcomes* out of `turn.rs` → `events_apply.rs` | S | — | `src/game/turn.rs`, **new** `src/game/events_apply.rs`, `src/game/mod.rs` *(one `mod` line)* | ✅ done | pier-t6 | struct/t4-genre | 567f348 |
+| **T7** | Split `world.rs` → `world/{mod,scene,charts,deals,venues}.rs` | L | T4 | `src/game/world.rs` → `src/game/world/**`, world unit tests relocate with code | ✅ done | grok-struct-t7 | struct/t4-genre | ba6a74c |
+| **T8** | Optional: `src/game/rng.rs` (action-stream helpers only) | S | T3 | `src/game/rng.rs` *(new)*, `src/game/core.rs`, `src/game/turn.rs` *(import paths)* | ✅ done | grok-struct-t8 | struct/t4-genre | 28596c5 |
+| **T9** | Split UI input handlers out of `app.rs` | M | — | `src/ui/app.rs`, **new** `src/ui/input/**` (or `src/ui/input.rs` + submodules), `src/ui/mod.rs` | ✅ done | antigravity | struct/t4-genre | 043ccf8 |
+| **T10** | Split UI drawing out of `render.rs` | M | — | `src/ui/render.rs`, **new** `src/ui/render/**`, `src/ui/mod.rs` | ✅ done | antigravity | struct/t4-genre | 7258107 |
+| **T12** | Split `render/modals.rs` → `modals/{deals,charts,marketing,file,pickers}` | S | T10 | `src/ui/render/modals.rs` → `src/ui/render/modals/**` only | ✅ done | grok-struct-t12 | struct/t4-genre | 356d957 |
+| **T11** | Cycle close: line-count report, board audit, archive note | S | T1–T7, T9–T10, T12 *(T8 optional)* | `HANDOFF.md`, optional short note in `CHANGELOG.md` under Internal | ✅ done | claude-t11 | struct/t4-genre | d7b1e59 |
+
+### Parallelism map (waves)
+
+```text
+Wave 0 (immediate, fully parallel — disjoint owns):
+  T1 (game tests)     T4 (genre)     T5 (actions)     T6 (events_apply)
+  T9 (ui input)       T10 (ui render)
+
+Wave 1:
+  T2 (constants)      ← after T1
+  T7 (world split)    ← after T4
+  T12 (modals split)  ← after T10  (parallel with T7 — disjoint owns)
+
+Wave 2:
+  T3 (core.rs shell)  ← after T2
+  T8 (rng.rs)         ← after T3, optional
+
+Wave 3:
+  T11 (close)         ← after required tasks (incl. T12)
+```
+
+**Conflict warnings (same branch — Owns are the mutex):**
+
+| Pair | Issue |
+|------|--------|
+| T1 ∥ T2 ∥ T3 | All touch `mod.rs` — **serialized** by prereqs (T1→T2→T3) |
+| T4 ∥ T7 | T7 must wait for T4 so genre is not moved twice |
+| T9 ∥ T10 | Both may touch `ui/mod.rs` — only add `mod` lines; never reformat the other’s files. Prefer one claimed at a time if unsure |
+| T12 ∥ T7 | Fully parallel — UI modals vs game world; no shared paths |
+| T6 | May add one `mod events_apply;` line in `game/mod.rs` while T1–T3 run — pull --rebase; keep that line-only |
+| Any ∥ any | **Pull --rebase before push.** Do not force-push unless the human says so |
+
+---
+
+## Target tree (end state)
+
+```text
+src/game/
+  mod.rs                 # module list + pub use only (≪ 80 lines)
+  constants.rs           # all tuning knobs + design comments
+  core.rs                # Game, GameAction, SupportTourOffer, new/init/save/load
+  rng.rs                 # T8: world/action stream builders + Game::action_rng*
+  genre.rs               # MusicGenre + Display + aliases (+ room for ability_weights later)
+  band.rs
+  player.rs
+  music.rs
+  events.rs              # EventManager / trigger selection (unchanged role)
+  events_apply.rs        # apply_random_event / apply_historical_event bodies
+  economy.rs
+  timeline.rs
+  turn.rs                # process_turn, visibility, offer hooks, game-over
+  actions/
+    mod.rs               # execute_action match only
+    studio.rs            # write, practice, record, quality helpers
+    live.rs              # gig, tour, live_fame_cap, regions
+    business.rs          # deals, marketing, support
+    rest.rs              # laze, break, doctor
+  world/
+    mod.rs               # GameWorld, market, update_week conductor
+    scene.rs             # SceneBand, population, momentum, scene releases
+    charts.rs            # ChartEntry, decay, submit
+    deals.rs             # PotentialDealOffer, buzz, generate, poach
+    venues.rs            # Venue + generation
+  tests/                 # #[cfg(test)] only
+    mod.rs               # harness: test_game, test_release, helpers
+    fame.rs
+    releases.rs          # pressing, charts entry, genre sales, marketing
+    deals.rs
+    support.rs
+    determinism.rs
+    save_compat.rs
+    …                    # split by concern; keep test fn names stable
+  sim.rs                 # balance lab (already test-only) — leave path or
+                         #   `pub mod sim` under tests/ only if T1 chooses to;
+                         #   default: keep `src/game/sim.rs` as today
+
+src/ui/
+  mod.rs
+  app.rs                 # App struct, run loop, thin dispatch
+  input/…                # key handlers by screen
+  render/
+    mod.rs               # draw() conductor + shared helpers
+    layout.rs / panels.rs / setup.rs / game_over.rs
+    modals/              # T12 — overlay family package
+      mod.rs             # re-exports draw_* for render::draw
+      deals.rs           # deals + support offer
+      charts.rs
+      marketing.rs
+      file.rs
+      pickers.rs         # venue, pressing, region
+```
+
+Line-count **soft caps** after the cycle (not enforced by CI):
+
+| Area | Soft max |
+|------|----------|
+| Any single production `.rs` under `game/` or `ui/` | ~400 lines preferred, ~500 hard |
+| `game/mod.rs` | ~80 |
+| `world/mod.rs` conductor | ~200 |
+| `actions/mod.rs` | ~80 |
+
+---
+
+## Task details
+
+### T1 — Tests out of `mod.rs`
+
+**Why:** ~750 lines of tests bury the real module surface and force every
+game PR to load a novel.
+
+**Do:**
+
+1. Create `src/game/tests/mod.rs` with the shared harness currently at
+   the top of `mod.rs`’s `#[cfg(test)] mod tests` (`test_game`,
+   `test_release`, `best_open_venue`, `test_deal_offer`, …).
+2. Split tests into concern files (suggested): `fame`, `releases`,
+   `deals`, `support`, `determinism`, `save_compat`, `smoke` — group by
+   what they assert, not 1:1 with production modules.
+3. Wire with:
+   ```rust
+   #[cfg(test)]
+   mod tests;
+   ```
+   in `src/game/mod.rs` (or `game.rs` after T3 — for T1, keep wiring in
+   `mod.rs`).
+4. **Keep every `#[test] fn` name identical** so `cargo test` output and
+   muscle memory stay stable.
+5. Leave `sim.rs` where it is (`src/game/sim.rs` + `#[cfg(test)] mod sim`)
+   unless moving it is trivial; do not merge sim into unit tests.
+
+**Acceptance:**
+
+- `src/game/mod.rs` has **no** `#[test]` functions left
+- `cargo test` → still 42 passed + 2 ignored, **same names**
+- Harness helpers are not `pub` outside `#[cfg(test)]`
+
+**Claim note:** while 🔒, nobody else edits the old tests block in `mod.rs`.
+
+---
+
+### T2 — `constants.rs`
+
+**Why:** balance knobs and stream salts should not live beside `Game`’s
+serde shape.
+
+**Do:**
+
+1. Move every tuning `const` / `pub const` currently at the top of
+   `mod.rs` (quality, sales, pressing, fame caps, idle, deals, genre
+   trend thresholds, `ACTION_STREAM_SALT`, `SETUP_STREAM_WEEK`, …) into
+   `src/game/constants.rs`, **keeping comments**.
+2. Re-export anything the UI or others need at the old path if useful:
+   ```rust
+   pub use constants::{PRESSING_TIERS, BREAK_WEEKS};
+   ```
+   so call sites outside `game` need not all change — or update call
+   sites in one go; either is fine if compile-clean.
+3. Modules that used bare `PRESSING_TIERS` via `super::*` should
+   `use crate::game::constants::*` or `super::constants::*` as appropriate.
+
+**Acceptance:** no gameplay consts left in `mod.rs` / `core.rs` except
+re-exports; tests pass unchanged.
+
+---
+
+### T3 — `core.rs` thin shell
+
+**Why:** `mod.rs` should only declare submodules.
+
+**Do:**
+
+1. Move `GameAction`, `SupportTourOffer`, `Game`, `default_seed`,
+   `impl Game` lifecycle (`new`, `log`, `take_turn_log`, `action_rng*`,
+   `initialize_player`, `save_game`, `load_game`) into `src/game/core.rs`.
+2. `mod.rs` becomes module declarations + `pub use core::{Game, GameAction, …}`
+   as needed by `main` / `ui`.
+3. Fix `actions` / `economy` / `turn` / `tests` / `sim` imports (`super::Game`
+   still works if they are children of `game` module tree — today they are
+   `mod actions` siblings; keep them as siblings of `core.rs` via
+   `mod core;` and `use crate::game::core::Game` **or** the common pattern:
+   ```rust
+   // mod.rs
+   mod core;
+   pub use core::*;
+   ```
+   Prefer the pattern that minimizes churn in `actions.rs` (`use super::*`).
+
+**Acceptance:** `mod.rs` ≪ 80 lines; `Game::new` / save-compat tests still pass.
+
+---
+
+### T4 — `genre.rs`
+
+**Why:** Musician §2 will hang `ability_weights()` on `MusicGenre`. It must
+not live inside a 1k-line world file.
+
+**Do:**
+
+1. Move `MusicGenre` + its `impl` (ALL, name, aliases, random*, Display,
+   Default, Hash, …) to `src/game/genre.rs`.
+2. `pub use` from `world` **or** update all imports to `crate::game::genre::MusicGenre`.
+   Prefer **one** canonical path: `crate::game::genre::MusicGenre`, and a
+   temporary re-export from `world` only if it reduces churn — document
+   which you chose in the PR.
+3. Do **not** move charts/scene/deals yet (that’s T7).
+
+**Acceptance:** `rg "enum MusicGenre" src/` → only `genre.rs`; all tests green.
+
+---
+
+### T5 — `actions/` package
+
+**Why:** practice / studio quality will grow with Musician; live and
+business actions should not share a 640-line file.
+
+**Do:** pure file split:
+
+| File | Contents (from current `actions.rs`) |
+|------|--------------------------------------|
+| `actions/mod.rs` | `mod studio; …` + `execute_action` |
+| `actions/studio.rs` | write, practice, record_*, quality helpers, song selection |
+| `actions/live.rs` | gig, tour, `live_fame_cap`, `get_sorted_regions` |
+| `actions/business.rs` | deals, marketing, support accept/decline |
+| `actions/rest.rs` | laze, break, doctor |
+
+Keep methods on `impl Game` with the same `pub(super)` visibility.
+Parent still `mod actions;` in `game/mod.rs` (directory replaces file).
+
+**Acceptance:** no `src/game/actions.rs` file left (only directory);
+`execute_action` still the single match hub; tests green.
+
+---
+
+### T6 — `events_apply.rs`
+
+**Why:** `apply_random_event` / historical outcomes are a slab inside
+`turn.rs`; personality will modulate outcomes later.
+
+**Do:**
+
+1. Move `apply_random_event` and `apply_historical_event` (and any private
+   helpers only they use) to `src/game/events_apply.rs` as `impl Game`.
+2. Leave trigger selection in `events.rs` and week orchestration in `turn.rs`.
+3. One new `mod events_apply;` in the game module tree.
+
+**Acceptance:** `turn.rs` drops substantially; event-related tests still pass
+(including full-season smoke / determinism).
+
+---
+
+### T7 — `world/` package
+
+**Why:** scene / charts / deals / venues are separate agent surfaces for
+Musician (lazy rosters) and future deal work.
+
+**Prereq T4** so genre is already outside.
+
+**Do:**
+
+| File | Owns |
+|------|------|
+| `world/mod.rs` | `GameWorld`, `MusicMarket`, `EconomicState`, `MusicTrend`, `update_week`, market helpers |
+| `world/scene.rs` | `SceneBand`, generate scene, `update_scene_*`, population bounds consts if scene-local |
+| `world/charts.rs` | `ChartEntry`, decay, submit, chart consts |
+| `world/deals.rs` | `PotentialDealOffer`, buzz consts, `generate_deal_offers`, `poach_rejected_deal` |
+| `world/venues.rs` | `Venue`, `generate_venues` |
+
+Move `#[cfg(test)]` world tests into `world/tests` or bottom of the file
+they assert on — keep test **function names**.
+
+**Acceptance:** no monolithic `src/game/world.rs`; `update_week` remains a
+short conductor; world + deal + chart tests green; scene size still 120–260.
+
+---
+
+### T8 — `rng.rs` (optional)
+
+**Why:** documents the sacred stream contract in one place.
+
+**Do only if Wave 2 is calm:** move `ACTION_STREAM_SALT`, `SETUP_STREAM_WEEK`,
+`action_rng_for_week`, `action_rng` into `rng.rs` (constants may stay in
+`constants.rs` with functions in `rng.rs` — pick one and don’t split salts
+from their docs).
+
+**Skip** if T3 already leaves these easy to find; mark board ✅ with note
+`skipped — low value` only with human OK, or leave ⬜ open.
+
+---
+
+### T9 — UI input split
+
+**Why:** setup / pickers / modals will grow for Musician UI (FUTURE §6).
+
+**Do:** move `handle_*_key` families out of `app.rs` into e.g.
+`ui/input/{setup,main,deals,marketing,pickers,file}.rs`. Keep `App` and
+`run` / top-level `handle_key` dispatch in `app.rs`.
+
+**Acceptance:** `app.rs` clearly under ~500 lines; setup genre test still
+passes; no input behavior change.
+
+---
+
+### T10 — UI render split
+
+**Why:** same as T9 for draw code.
+
+**Do:** split `draw_*` into `ui/render/{layout,panels,modals,…}.rs`.
+Shared style helpers can live in `render/mod.rs`.
+
+**Acceptance:** `render.rs` file gone or thin; visual structure unchanged
+(no drive-by color/layout redesigns).
+
+---
+
+### T12 — Split render modals package
+
+**Why:** After T10, `render/modals.rs` was still ~470–500 lines — the
+largest remaining UI file. Musician UI will add more overlays; keep each
+modal family small. **Not part of T7** (game world); parallel-safe.
+
+**Prereq:** T10 ✅.
+
+**Do:** pure move only:
+
+| File | Contents |
+|------|----------|
+| `modals/mod.rs` | submodule list + `pub(super) use` of each `draw_*` |
+| `modals/deals.rs` | deals modal + support-slot modal |
+| `modals/charts.rs` | charts modal |
+| `modals/marketing.rs` | marketing release/campaign modal |
+| `modals/file.rs` | save/load modal |
+| `modals/pickers.rs` | venue, pressing-run, region pickers |
+
+Keep `render/mod.rs` calling `modals::draw_*` (re-exports). Shared helpers
+stay in `render/mod.rs` (`centered_rect`, `ACCENT`, …). Leaf draw fns may
+use `pub(crate)` so they can be re-exported (same nested-module visibility
+pattern as T5/T9).
+
+**Acceptance:** no monolithic `render/modals.rs`; each leaf file under ~250
+lines preferred; `cargo test` / clippy / fmt clean; no visual redesign.
+
+---
+
+### T11 — Cycle close
+
+**Do:**
+
+1. Confirm board: all required tasks ✅ (incl. T12), claims consistent with git history.
+2. Paste a short **line-count table** (production files only) under Notes
+   below.
+3. Add 2–4 lines under CHANGELOG **Internal** (unreleased / 0.5.1) listing
+   the structural split — no fake player-facing notes.
+4. Optionally move this file to `docs/archive/HANDOFF-v0.5.1-structure.md`
+   when the human opens the Musician cycle (human trigger).
+
+**Acceptance:** `cargo test` / clippy / fmt clean on `main`; HANDOFF board
+all required ✅.
+
+---
+
+## Shared files cheat sheet
+
+| Path | Who may touch |
+|------|----------------|
+| `src/game/mod.rs` | T1 (tests wiring), T2, T3, T6 (`mod` line only), T4/T5/T7 (`mod` / `pub use` lines only) — **serialize** via prereqs + rebase |
+| `src/game/world.rs` → `world/` | T4 then T7 only |
+| `src/game/actions.rs` → `actions/` | T5 only |
+| `src/game/turn.rs` | T6 primarily; T8 imports only |
+| `src/ui/app.rs` | T9 |
+| `src/ui/render.rs` → `render/**` | T10; then T12 owns only `render/modals*` |
+| `HANDOFF.md` board rows | **Every agent** for their claim/complete only — do not rewrite other tasks’ details |
+| `FUTURE.md` | nobody this cycle |
+| `data/**` | nobody this cycle |
+| `tests/fixtures/**` | nobody this cycle |
+
+---
+
+## Verification cheatsheet
+
+```bash
+cargo test
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+# determinism / save still in the suite:
+cargo test same_seed_and_same_choices_replay_the_same_career
+cargo test saves_from_v0_4_still_load
+cargo test worldgen_is_reproducible_per_seed
+```
+
+After T7:
+
+```bash
+cargo test scene_
+cargo test chart_
+cargo test independent_labels_scout
+```
+
+---
+
+## Notes (agents append one-liners here)
+
+_Example:_  
+`2026-07-13 T5 claimed by grok-struct-1 on struct/t4-genre`
+
+- 2026-07-13 T4 done by grok-struct-t4 on `struct/t4-genre`: canonical path `crate::game::genre::MusicGenre`; no world re-export; `random`/`random_trending` are `pub(crate)`.
+- 2026-07-13 T9 done by antigravity on `struct/t4-genre`.
+- 2026-07-13 **Policy:** single shared branch `struct/t4-genre` for the whole structure cycle — no per-task branches. Abandoned names like `struct/t1-tests-out` must not be used; rebase any stray work onto `struct/t4-genre`.
+- 2026-07-13 T5 done by grok-struct-t5 on `struct/t4-genre`: `actions.rs` → `actions/{mod,studio,live,business,rest}.rs`; action methods use `pub(in crate::game)` so nested modules stay visible to game tests/turn.
+- 2026-07-13 T6 done by pier-t6 on `struct/t4-genre`: `apply_random_event` + `apply_historical_event` → `events_apply.rs` as `pub(super) impl Game`; `turn.rs` down from 538 to 285 lines; `mod events_apply;` in `mod.rs`. ⚠ cargo test / git push blocked by env (SSL + index-lock); code structure verified manually.
+- 2026-07-13 T10 done by antigravity on `struct/t4-genre`: `render.rs` → `render/{mod,setup,layout,panels,modals,game_over}.rs`; shared helpers (centered_rect, gauge, scale_color, format_population) in `render/mod.rs`; `pub(crate)` for ACCENT const.
+- 2026-07-13 T12 claimed+done by grok-struct-t12 on `struct/t4-genre`: `render/modals.rs` → `modals/{mod,deals,charts,marketing,file,pickers}.rs` with re-exports; parallel-safe with T7.
+- 2026-07-13 T7 done by grok-struct-t7 on `struct/t4-genre`: `world.rs` → `world/{mod,scene,charts,deals,venues}.rs`; public API re-exported from `world/mod.rs`; tests stay under `world::tests`. No impact on T2 (disjoint owns).
+- 2026-07-13 T2 done by pier-t2 (extract) + grok-t2-polish (land): 40 game tuning consts → `src/game/constants.rs`; data constants re-exported; `pub use constants::{PRESSING_TIERS, BREAK_WEEKS}`; uniform `use …constants::{self, *}` (or `use …constants` where only path form); clippy clean; committed to `struct/t4-genre`.
+- 2026-07-13 T3 done by antigravity on `struct/t4-genre`: `Game`, `GameAction`, `SupportTourOffer`, and core lifecycle/save/load logic moved to `core.rs`; `mod.rs` reduced to submodule definitions and re-exports; clippy clean.
+- 2026-07-13 T8 done by grok-struct-t8 on `struct/t4-genre`: `rng.rs` holds splitmix64 mixer + `world_rng_for_week` / `action_rng_for_week` + `Game::action_rng*`; salts stay in `constants.rs`; turn uses world builder. Determinism tests green.
+- 2026-07-14 T11 done by claude-t11 on `struct/t4-genre`. **Cycle close, cut as 0.5.1.** Board audit: T1–T10 + T12 all ✅ with real commit SHAs (verified via `git cat-file`); T8 (optional) done. Full suite green: `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test` → 42 passed / 2 ignored (same names as the 0.5.0 baseline). CHANGELOG 0.5.1 Internal added; `Cargo.toml`/`Cargo.lock` bumped 0.5.0 → 0.5.1. Archive of this file deferred to the human Musician-cycle trigger (step 4).
+
+### T11 line-count report (production `.rs`; `tests/` and `sim.rs` excluded)
+
+Monolith → package, **start-of-cycle → now** (lines):
+
+| Was | Lines | Now |
+|-----|-------|-----|
+| `game/mod.rs` | 1060 → **27** | shell; + `core` 189, `constants` 97, `rng` 67, `genre` 85, `events_apply` 266, `tests/**` |
+| `game/world.rs` | 1090 → `world/**` | `mod` 486, `scene` 253, `deals` 186, `charts` 68, `venues` 49 |
+| `game/actions.rs` | 719 → `actions/**` | `studio` 279, `live` 244, `business` 162, `rest` 41, `mod` 41 |
+| `game/turn.rs` | 537 → **281** | event outcomes → `events_apply` 266 |
+| `ui/render.rs` | 1052 → `render/**` | `panels` 319, `setup` 101, `mod` 84, `game_over` 67, `layout` 33, `modals/{pickers 222, deals 146, marketing 77, charts 60, file 44, mod 15}` |
+| `ui/app.rs` | 986 → **420** | + `input/{pickers 170, main 127, setup 120, deals 82, marketing 72, file 46, mod 8}` |
+
+Largest production file now: `game/world/mod.rs` at **486** (< 500 hard cap). Shell modules meet targets: `game/mod.rs` 27 (≪80), `actions/mod.rs` 41 (≪80), `ui/render/modals/mod.rs` 15, `ui/input/mod.rs` 8. All production `.rs` ≤ 486 lines.


### PR DESCRIPTION
## What this opens

The **v0.6 Life Cycle** — the feature cycle the v0.5.1 structure work was preparing for, prioritized ahead of the Musician cycle. All design decisions were made in discussion; this PR captures them and sets up the coordination surface.

### Contents

- **`docs/DESIGN-v0.6-life-cycle.md`** — the decided design:
  - **§A Four bars** — health / stress / happiness / creativity, stress as the central pressure valve; energy removed as a mechanic (field stays serialized, dormant). Writing consumes creativity only when writing too much or under stress.
  - **§B Per-show analysis** — every gig and tour stop resolves individually (5 shows/tour-week) with reception + box office + within-tour momentum, and a per-day tour report. Band rating is the dominant term; creativity is upside, never a multiplier.
  - **§C Fame gravity** — peak floors by 15s (30→10 … 95+ with 10 hits→75), tiered grace (2 weeks at the bottom, 1 year at 95+), accelerating ramp (−1…−5/wk), comeback ×2 below peak, three activity rules (public action / on the charts / 60+ with a release in the past year), and label single-cuts on the label's own volition.
  - **§D Living sales tail** — gentler decay, tail responds to current fame/marketing (also fixes post-launch marketing doing nothing).
  - **§E Endless game** — rockstar status becomes a milestone, not an ending.
  - **§F Data-driven incidents** — `data/incidents.json` schema, more and more-varied incidents, content out of the Rust source. Drugs deferred.
- **`HANDOFF.md`** — new task board (L1–L11) with the claim protocol, waves, and conflict map from the structure cycle. Work branch: `life/v0.6`.
- **`docs/archive/HANDOFF-v0.5.1-structure.md`** — the completed structure cycle handoff, archived (the deferred T11 step 4).

No code changes; `cargo test` untouched (43 passed, 2 ignored on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added the v0.6 Life Cycle design specification.
  - Documented stress, happiness, creativity, fame, touring, sales, incidents, and progression systems.
  - Updated lifecycle handoff procedures, task planning, verification requirements, and compatibility guidelines.
  - Archived the previous v0.5.1 structure-hardening handoff for reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->