### PR TITLE
money 0.7.1: fix recoupment rescale (#20), sell-out log order (#21), and their bug classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ Notable changes to Rocker, newest first. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [SemVer](https://semver.org/) in spirit — this is a game, the API is vibes.
 
+## 0.7.1 — 2026-07-17
+
+Money Cycle repairs: two reported bugs (#20, #21) plus everything a sweep
+for their bug classes turned up.
+
+### Fixed
+
+- **Label recoupment is possible again** (#20). The M7 sales rescale
+  tripled the copies every pressing charged to the recoupment ledger while
+  royalty dollars stayed flat, so below a 30% royalty the advance could
+  mathematically never be repaid — every major and most indies. The
+  per-copy ledger charge is rescaled (and then tuned to $0.05/copy) so the
+  median signed act recoups its advance before the term's halfway mark —
+  now asserted in the sim lab so it can't silently regress again.
+- **Indie pressing pays for itself again.** The same rescale miss on the
+  player's side: per-copy pressing bills were still on the pre-M7 scale, so
+  a sold-out album run *lost* money outright in every era with a recording
+  cost modifier above 4/3 — five of the ten. Per-copy costs now divide by
+  the income divisor, restoring the pre-M7 margins; a new test pins a
+  fully-sold run out-earning its bill in every era.
+- **Sell-out news reads in order** (#21). The sold-out line now reports
+  the run that actually sold out (not the ledger-inflated post-restock
+  count), and the label's fresh-run announcement follows the sell-out it
+  reacts to instead of preceding it. First-run certification news got the
+  same treatment: sales line, then the award, then the restock.
+- **Instant actions no longer mint bonus sales weeks.** The weekly sales
+  pass ran after every action — including instant ones (marketing,
+  lifestyle moves, re-presses, deal responses) that don't advance the
+  calendar — so each one re-sold a full catalog-tail week: free copies,
+  income, recoupment paydown, and certification progress. The pass now
+  resolves at most once per game week.
+- **"Fame +N" tells the truth.** Gig, tour, support-slot, and record-sales
+  lines all reported the pre-multiplier fame gain: during a comeback the
+  band actually gained double what the log said, and at a cap it gained
+  less. The log (and the tour report) now show the fame actually applied.
+  Same for a tour's regional fame line when the 100-cap eats part of the
+  rolled gain.
+
 ## 0.7.0 — 2026-07-16
 
 The Money Cycle: where the record business gets its hooks into you. Tours

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,16 @@ for their bug classes turned up.
   less. The log (and the tour report) now show the fame actually applied.
   Same for a tour's regional fame line when the 100-cap eats part of the
   rolled gain.
+- **Label pressing runs carry the M7 rescale, and certifications are
+  honestly reachable again.** Label run sizes were still sized for the
+  old demand scale, so a signed act's first run nearly always sold out
+  and the over-cap demand silently evaporated — runs now press 3× (the
+  same coupling as the other per-copy fixes). And with the bonus-sales
+  exploit closed, the certification balance it had been propping up is
+  retuned through the catalog tail (gentler decay, higher weekly rate):
+  a signed 15-year career medians 3 certifications in the balance sweep,
+  inside the design's 1–3 target, where the exploit-free game previously
+  allowed none — for anyone, ever.
 
 ## 0.7.0 — 2026-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ for their bug classes turned up.
   old demand scale, so a signed act's first run nearly always sold out
   and the over-cap demand silently evaporated — runs now press 3× (the
   same coupling as the other per-copy fixes). And with the bonus-sales
-  exploit closed, the certification balance it had been propping up is
+  exploit closed, the certification balance previously propped up by that exploit is
   retuned through the catalog tail (gentler decay, higher weekly rate):
   a signed 15-year career medians 3 certifications in the balance sweep,
   inside the design's 1–3 target, where the exploit-free game previously

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1121,7 +1121,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rocker"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "rand",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocker"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 rust-version = "1.88"
 description = "A rock star management simulation game starting in 1970"

--- a/src/game/actions/business.rs
+++ b/src/game/actions/business.rs
@@ -295,16 +295,21 @@ impl Game {
             .player
             .health
             .saturating_sub(constants::TOUR_HEALTH_COST_PER_WEEK.saturating_mul(weeks));
-        self.band.gain_fame(offer.fame_gain);
+        // Report the fame actually applied (comeback doubling, caps), not
+        // the offer's raw number.
+        let fame_applied = self.band.gain_fame(offer.fame_gain);
         self.week += offer.weeks;
         self.log(format!(
             "🎟️ Opened for {} for {} weeks — ${} and a taste of the big stage (fame +{}).",
-            offer.host_band, offer.weeks, offer.pay, offer.fame_gain
+            offer.host_band, offer.weeks, offer.pay, fame_applied
         ));
 
         if rng.gen_bool(0.25) {
-            self.band.gain_fame(2);
-            self.log("🔥 Their crowd adopted you — encores every night (+2 fame).");
+            let encore_fame = self.band.gain_fame(2);
+            self.log(format!(
+                "🔥 Their crowd adopted you — encores every night (+{} fame).",
+                encore_fame
+            ));
         }
         Ok(())
     }

--- a/src/game/actions/live.rs
+++ b/src/game/actions/live.rs
@@ -306,7 +306,10 @@ impl Game {
         let capacity = venue.capacity;
 
         self.player.earn_money(earnings);
-        self.band
+        // Report the fame actually applied (comeback doubling, caps), not
+        // the raw pre-multiplier gain.
+        let fame_applied = self
+            .band
             .gain_fame_capped(fame_gain, venue_ceiling.min(live_cap));
 
         self.player.stress = (self.player.stress + GIG_STRESS_COST).min(constants::MAX_STRESS);
@@ -322,10 +325,10 @@ impl Game {
                 capacity,
                 take: earnings,
             }],
-            fame_gain,
+            fame_applied,
         ));
 
-        if fame_gain > 0 {
+        if fame_applied > 0 {
             self.log(format!(
                 "🎤 Played '{}' — a {} night, sold {}/{} tickets, earned ${}, fame +{}.",
                 venue_name,
@@ -333,7 +336,7 @@ impl Game {
                 attendance,
                 capacity,
                 earnings,
-                fame_gain
+                fame_applied
             ));
         } else if self.band.fame >= live_cap {
             self.log(format!(
@@ -600,12 +603,14 @@ impl Game {
             });
         }
 
-        // Cap the fame gain against the live ceiling before building the
-        // report so the Tour Report screen shows the fame actually applied
-        // to the band, not the pre-cap value.
+        // Cap the fame gain against the live ceiling and apply it before
+        // building the report, so the Tour Report screen and the 🚌 line
+        // both show the fame actually applied to the band — comeback
+        // doubling and caps included, not the pre-cap request.
         let live_cap = self.live_fame_cap();
         let fame_gain = pot.fame_gain.min(live_cap.saturating_sub(self.band.fame));
-        let report = TourReport::from_rows(rows, fame_gain);
+        let fame_applied = self.band.gain_fame_capped(fame_gain, live_cap);
+        let report = TourReport::from_rows(rows, fame_applied);
         if report.went_very_well() {
             self.player.happiness = (self.player.happiness + TOUR_WENT_WELL_HAPPINESS_GAIN)
                 .min(constants::MAX_HAPPINESS);
@@ -625,12 +630,13 @@ impl Game {
         self.player.spend_money(pot.cost);
         self.player.earn_money(gross_sum);
 
-        self.band.gain_fame_capped(fame_gain, live_cap);
-
         let regional_fame_gain = pot.regional_fame_gain_base
             + rng.gen_range(0..=TOUR_REGIONAL_FAME_GAIN_RNG_SPREAD as u16);
         let new_regional_fame =
             (pot.regional_fame_current as u16 + regional_fame_gain).min(100) as u8;
+        // The 100-cap can eat part of the rolled gain — report the delta
+        // that actually landed, not the roll.
+        let regional_fame_applied = new_regional_fame - pot.regional_fame_current;
         self.regional_fame
             .insert(pot.regional_fame_key.clone(), new_regional_fame);
 
@@ -648,9 +654,9 @@ impl Game {
             avg_verdict.label(),
             gross_sum,
             pot.cost,
-            fame_gain,
+            fame_applied,
             new_regional_fame,
-            regional_fame_gain
+            regional_fame_applied
         ));
         if report.went_very_well() {
             self.log("🌟 The tour went very well — spirits (and inspiration) are high.");

--- a/src/game/band.rs
+++ b/src/game/band.rs
@@ -215,14 +215,19 @@ impl Band {
     /// peak it has already reached, the gain is doubled (the comeback rule,
     /// design §C); the result is clamped to `MAX_FAME` and the peak updated.
     /// Fame *losses* (idle decay, bad events) must not route through here.
-    pub fn gain_fame(&mut self, amount: u8) {
-        self.gain_fame_capped(amount, crate::game::constants::MAX_FAME);
+    pub fn gain_fame(&mut self, amount: u8) -> u8 {
+        self.gain_fame_capped(amount, crate::game::constants::MAX_FAME)
     }
 
     /// Like [`Band::gain_fame`], but the result also respects a ceiling —
     /// the live-fame caps: comeback doubling never carries fame past `cap`.
     /// A cap already at or below current fame never reduces fame.
-    pub fn gain_fame_capped(&mut self, amount: u8, cap: u8) {
+    ///
+    /// Returns the fame actually applied — after comeback doubling and the
+    /// caps — which is what any "fame +N" log line must report: the raw
+    /// `amount` understates a comeback gain 2× and overstates a capped one.
+    pub fn gain_fame_capped(&mut self, amount: u8, cap: u8) -> u8 {
+        let before = self.fame;
         let ceiling = cap.max(self.fame);
         let peak = self.effective_peak_fame();
         let multiplier = if self.fame < peak {
@@ -235,6 +240,7 @@ impl Band {
             .min(u16::from(ceiling))
             .min(u16::from(crate::game::constants::MAX_FAME)) as u8;
         self.peak_fame = peak.max(self.fame);
+        self.fame - before
     }
 
     pub fn get_fame_level(&self) -> &str {

--- a/src/game/constants.rs
+++ b/src/game/constants.rs
@@ -48,12 +48,23 @@ pub(super) const INDIE_INCOME_PER_COPY: u32 = 2;
 pub(super) const LABEL_INCOME_PER_COPY: u32 = 3;
 
 // Living sales tail: post-launch decay and influence [tune].
-pub(super) const TAIL_DIVISOR_WEEKS_PER_STEP: u32 = 3;
+//
+// The decay step (3 → 4) and the tail unit rate (a magic `/ 5` in the tail
+// loop → the named `/ 3` below) were retuned together when the weekly sales
+// pass gained its once-per-week guard: instant actions had been re-running
+// the tail at the same week's (early, high) rate without advancing the decay
+// clock, and the §D/§F certification balance — median signed 15-year career
+// reaches 1–3 silvers; a home-market act can reach Silver at all — was
+// unknowingly calibrated on that bonus volume. These put the legitimate
+// weekly tail where the exploit-inflated one effectively was: the sweep's
+// label-loyalist lands med 3 certs (was 5 with the exploit, 0 without the
+// retune). Re-check that sweep column before moving either. [tune]
+pub(super) const TAIL_DIVISOR_WEEKS_PER_STEP: u32 = 4;
 pub(super) const TAIL_MARKETING_WEIGHT: f32 = 1.8;
 pub(super) const TAIL_FAME_WEIGHT: f32 = 0.3;
-/// The tail moves this fraction (1/N) of the first-run per-week unit rate
-/// (was a magic `/ 5` in the tail loop). [tune]
-pub(super) const TAIL_UNITS_DIVISOR: u32 = 5;
+/// The tail moves this fraction (1/N) of the first-run per-week unit rate.
+/// Retuned with `TAIL_DIVISOR_WEEKS_PER_STEP` above. [tune]
+pub(super) const TAIL_UNITS_DIVISOR: u32 = 3;
 
 // Pressing runs. Independents choose a run and pay setup plus per-copy
 // costs; a label presses to the size of its network and your name. The
@@ -85,8 +96,18 @@ pub(super) const PRESSING_SETUP_ALBUM: f32 = 100.0;
 // carry these along. [tune]
 pub(super) const PRESSING_PER_COPY_SINGLE: f32 = 0.10 / SALES_INCOME_DIVISOR as f32;
 pub(super) const PRESSING_PER_COPY_ALBUM: f32 = 0.50 / SALES_INCOME_DIVISOR as f32;
-pub(super) const LABEL_PRESSING_PER_REACH: u32 = 100;
-pub(super) const LABEL_PRESSING_PER_FAME: u32 = 50;
+// Label pressing run sizes are COUPLED to the M7 sales rescale like the
+// per-copy dollar constants above: `UNITS_PER_SCORE_POINT` tripled the
+// copies a sales score demands, and a run is denominated in copies, so the
+// run a label presses must triple with it (100/50 → 300/150). Left on the
+// old scale, a signed act's first run nearly always sold out and the
+// over-cap demand was silently discarded — a fame-100 act's hit leaked most
+// of its first-week sales, which is why no signed career could accumulate
+// the 50k copies Silver asks for (§D/§F) once the once-per-week sales-pass
+// guard stopped instant actions from minting bonus tail weeks. If
+// `UNITS_PER_SCORE_POINT` moves again, carry these along. [tune]
+pub(super) const LABEL_PRESSING_PER_REACH: u32 = 300;
+pub(super) const LABEL_PRESSING_PER_FAME: u32 = 150;
 
 // Distribution model: how much of a release's potential audience you can
 // actually reach. Labels bring their market_reach; independents are capped

--- a/src/game/constants.rs
+++ b/src/game/constants.rs
@@ -51,6 +51,9 @@ pub(super) const LABEL_INCOME_PER_COPY: u32 = 3;
 pub(super) const TAIL_DIVISOR_WEEKS_PER_STEP: u32 = 3;
 pub(super) const TAIL_MARKETING_WEIGHT: f32 = 1.8;
 pub(super) const TAIL_FAME_WEIGHT: f32 = 0.3;
+/// The tail moves this fraction (1/N) of the first-run per-week unit rate
+/// (was a magic `/ 5` in the tail loop). [tune]
+pub(super) const TAIL_UNITS_DIVISOR: u32 = 5;
 
 // Pressing runs. Independents choose a run and pay setup plus per-copy
 // costs; a label presses to the size of its network and your name. The
@@ -69,8 +72,19 @@ pub const PRESSING_TIERS: [(&str, u32); 4] = [
 ];
 pub(super) const PRESSING_SETUP_SINGLE: f32 = 25.0;
 pub(super) const PRESSING_SETUP_ALBUM: f32 = 100.0;
-pub(super) const PRESSING_PER_COPY_SINGLE: f32 = 0.10;
-pub(super) const PRESSING_PER_COPY_ALBUM: f32 = 0.50;
+// Per-copy pressing costs are COUPLED to the M7 sales rescale, the same way
+// as `LABEL_RECOUP_PRESSING_PER_COPY` below (issue #20's bug class): M7
+// tripled the copies a score moves (`UNITS_PER_SCORE_POINT`) while
+// `SALES_INCOME_DIVISOR` kept income dollars flat, so an indie now presses
+// 3× the copies for the same money and the per-copy bill must divide by the
+// same ratio. At the pre-M7 $0.50/album the margin went negative in every
+// era with `recording_cost_modifier > 4/3` — a sold-out album run lost money
+// unconditionally. Dividing restores the pre-M7 economics exactly (a Garage
+// album's bill lands back on v0.6's $350 × era mod against the same capped
+// income). If `UNITS_PER_SCORE_POINT` or `SALES_INCOME_DIVISOR` move again,
+// carry these along. [tune]
+pub(super) const PRESSING_PER_COPY_SINGLE: f32 = 0.10 / SALES_INCOME_DIVISOR as f32;
+pub(super) const PRESSING_PER_COPY_ALBUM: f32 = 0.50 / SALES_INCOME_DIVISOR as f32;
 pub(super) const LABEL_PRESSING_PER_REACH: u32 = 100;
 pub(super) const LABEL_PRESSING_PER_FAME: u32 = 50;
 
@@ -459,9 +473,28 @@ pub(super) const TOUR_REGIONAL_FAME_GAIN_RNG_SPREAD: u8 = 5;
 // ============================================================================
 
 /// Per-copy pressing cost the label books against recoupment (design §E-2:
-/// $0.30/copy). Applied to the label's pressing run at each release and to
-/// every auto-repress run (§E-1 label half). [tune]
-pub(super) const LABEL_RECOUP_PRESSING_PER_COPY: f32 = 0.30;
+/// $0.30/copy at the pre-M7 10-units-per-point scale). Applied to the label's
+/// pressing run at each release and to every auto-repress run (§E-1 label
+/// half).
+///
+/// COUPLED to the M7 sales rescale: `UNITS_PER_SCORE_POINT` tripled the
+/// copies a score moves while `SALES_INCOME_DIVISOR` kept royalty dollars
+/// flat, so this per-copy charge must divide by at least the same ratio
+/// ($0.30 ÷ 3 = $0.10). Left at $0.30 it outran every royalty below 30% and
+/// recoupment was structurally impossible (issue #20).
+///
+/// Then halved once more to $0.05 (break-even at a 5% royalty — majors net
+/// $0.05–0.07/copy after pressing, indies far more): issue #20's $0.10
+/// suggestion was calibrated while instant actions still re-ran the weekly
+/// sales pass, inflating catalog royalty velocity; with that double-count
+/// fixed, $0.10 left the median first deal recouping at ~58% of its term,
+/// missing the §F target ("median signed act recoups the advance before the
+/// term's halfway mark" — asserted by
+/// `median_signed_act_recoups_the_advance_before_the_terms_halfway_mark`,
+/// which is the number to re-check first if this moves). If
+/// `UNITS_PER_SCORE_POINT` or `SALES_INCOME_DIVISOR` move again, carry this
+/// constant along. [tune]
+pub(super) const LABEL_RECOUP_PRESSING_PER_COPY: f32 = 0.05;
 /// Recoupment cost per point of promo push the label applies in
 /// `apply_label_promo` (design §E-2: $15/point). [tune]
 pub(super) const LABEL_RECOUP_PROMO_PER_PUSH: i32 = 15;

--- a/src/game/core.rs
+++ b/src/game/core.rs
@@ -131,6 +131,16 @@ pub struct Game {
     /// the exact reach the old, single indie formula already gave.
     #[serde(default)]
     pub current_distribution_channel: DistributionChannel,
+    /// The last week the weekly sales pass
+    /// (`process_music_releases_and_marketing`) resolved. The pass fires
+    /// after EVERY action, but instant actions (marketing, lifestyle,
+    /// re-press, deal responses) don't advance the calendar — without this
+    /// guard each one re-sold a full catalog-tail week inside the same game
+    /// week: bonus copies, income, recoupment paydown, and certification
+    /// progress per instant action. `#[serde(default)]` (`None`) so an old
+    /// save's first pass after load runs normally.
+    #[serde(default)]
+    pub(super) last_sales_pass_week: Option<u32>,
 }
 
 impl Game {
@@ -173,6 +183,7 @@ impl Game {
             turn_log,
             rockstar_achieved: false,
             current_distribution_channel: DistributionChannel::default(),
+            last_sales_pass_week: None,
         })
     }
 

--- a/src/game/economy.rs
+++ b/src/game/economy.rs
@@ -222,13 +222,15 @@ impl Game {
     /// `plan_pressing` would hand it — restocking the catalog tail. The new
     /// pressing cost joins the recoupment ledger (§E-2). The indie,
     /// player-initiated re-press is M6's job, not this.
-    fn label_auto_repress(&mut self, release: &mut Release, reason: &str) {
-        let Some(deal) = self.band.current_deal() else {
-            return;
-        };
+    ///
+    /// Returns the restock announcement instead of logging it, so the caller
+    /// can emit it in story order — after the sales/sold-out lines it reacts
+    /// to, not before them (issue #21).
+    fn label_auto_repress(&mut self, release: &mut Release, reason: &str) -> Option<String> {
+        let deal = self.band.current_deal()?;
         let fresh_run = self.label_pressing_size(deal);
         if fresh_run == 0 {
-            return;
+            return None;
         }
         let label_name = deal.label_name.clone();
         release.copies_pressed = release.copies_pressed.saturating_add(fresh_run);
@@ -236,11 +238,10 @@ impl Game {
         if let Some(deal) = self.band.record_deal.as_mut() {
             deal.unrecouped = deal.unrecouped.saturating_add(outlay);
         }
-        let release_name = release.name.clone();
-        self.log(format!(
+        Some(format!(
             "🏭 {} presses a fresh run of '{}' ({}) — {} more copies in stores.",
-            label_name, release_name, reason, fresh_run
-        ));
+            label_name, release.name, reason, fresh_run
+        ))
     }
 
     /// M5 (§E-1, label half — tail path): [`Game::label_auto_repress`] for a
@@ -354,13 +355,20 @@ impl Game {
     }
 
     /// Apply the certification awards to the game state for a given level transition.
+    ///
+    /// Returns the 🏆 announcement lines instead of logging them, so each
+    /// caller can emit them in story order — the first-run path holds them
+    /// until after the 💿/📦 sales lines the certification reacts to (the
+    /// same deferral as the 🏭 restock line, issue #21's bug class).
+    #[must_use]
     pub(crate) fn apply_certification_awards(
         &mut self,
         old_level: u8,
         new_level: u8,
         release_name: &str,
         copies_sold: u32,
-    ) {
+    ) -> Vec<String> {
+        let mut lines = Vec::new();
         // Award bumps for each level from the old to the new (shouldn't normally skip).
         // Index into the bumps arrays (silver=0, gold=1, platinum=2).
         for level in (old_level + 1)..=new_level.min(3) {
@@ -372,8 +380,7 @@ impl Game {
                 _ => unreachable!(),
             };
 
-            // Log the achievement.
-            self.log(format!(
+            lines.push(format!(
                 "🏆 '{}' is certified {} — {} copies sold.",
                 release_name, level_name, copies_sold
             ));
@@ -408,7 +415,7 @@ impl Game {
             let multiplatinum_count = new_level - old_level.max(3);
             for _ in 0..multiplatinum_count {
                 // Award platinum bumps again for each multi-platinum tier.
-                self.log(format!(
+                lines.push(format!(
                     "🏆 '{}' is certified PLATINUM — {} copies sold.",
                     release_name, copies_sold
                 ));
@@ -426,9 +433,19 @@ impl Game {
                     .min(100);
             }
         }
+        lines
     }
 
     pub(super) fn process_music_releases_and_marketing(&mut self) {
+        // One sales week per calendar week. This pass runs after every
+        // action, but instant actions don't advance `self.week` — re-running
+        // the catalog tail for a week that already sold would mint bonus
+        // copies, income, recoupment paydown, and certification progress on
+        // every instant action.
+        if self.last_sales_pass_week == Some(self.week) {
+            return;
+        }
+        self.last_sales_pass_week = Some(self.week);
         let current_week = self.week;
 
         // M5 (§E-2): snapshot the recoupment ledger so the weekly status line
@@ -512,13 +529,17 @@ impl Game {
                 let to_player = self.apply_recoupment(income);
                 self.player.earn_money(to_player);
 
-                // Check for certification milestones (§D).
+                // Check for certification milestones (§D). The 🏆 lines are
+                // held back like the 🏭 restock below: the award's mechanics
+                // (fame bump sizes the fresh run) stay here, but its news
+                // must follow the 💿/📦 sales lines that caused it.
                 let mut certified_this_pass = false;
+                let mut cert_lines = Vec::new();
                 if let Some((old_level, new_level)) = Self::compute_certification_awards(&release) {
                     let release_name = release.name.clone();
                     let copies_sold = release.copies_sold;
                     release.certified = new_level;
-                    self.apply_certification_awards(
+                    cert_lines = self.apply_certification_awards(
                         old_level,
                         new_level,
                         &release_name,
@@ -532,11 +553,17 @@ impl Game {
                 // cost joins the ledger, §E-2). Sold-out takes priority — a
                 // sold-out record can't also have certified this same pass
                 // without more stock, and a single fresh run answers both.
+                // The 📦 line must report the run that actually sold out, and
+                // the 🏭 restock must be announced after it (issue #21) — so
+                // the pre-re-press count is captured here and the restock
+                // line is held back until the sales beats have logged.
+                let first_run_pressed = release.copies_pressed;
+                let mut repress_log = None;
                 if self.band.current_deal().is_some() {
                     if sold_out {
-                        self.label_auto_repress(&mut release, "sold out");
+                        repress_log = self.label_auto_repress(&mut release, "sold out");
                     } else if certified_this_pass {
-                        self.label_auto_repress(&mut release, "certified");
+                        repress_log = self.label_auto_repress(&mut release, "certified");
                     }
                 }
 
@@ -553,11 +580,13 @@ impl Game {
                 } else {
                     (sales_score / 300).min(4) as u8
                 };
-                self.band.gain_fame(fame_gain);
-                if fame_gain > 0 {
+                // Log the fame actually applied (comeback doubling, caps),
+                // not the raw pre-multiplier gain.
+                let fame_applied = self.band.gain_fame(fame_gain);
+                if fame_applied > 0 {
                     self.log(format!(
                         "💿 '{}' {} — moved {} copies, first-run earnings: ${}, fame +{}.",
-                        release.name, verdict, units_sold, income, fame_gain
+                        release.name, verdict, units_sold, income, fame_applied
                     ));
                 } else {
                     self.log(format!(
@@ -568,8 +597,14 @@ impl Game {
                 if sold_out {
                     self.log(format!(
                         "📦 '{}' sold out — all {} copies gone; demand was there for more.",
-                        release.name, release.copies_pressed
+                        release.name, first_run_pressed
                     ));
+                }
+                for line in cert_lines {
+                    self.log(line);
+                }
+                if let Some(line) = repress_log {
+                    self.log(line);
                 }
 
                 let release_genre = release.genre.clone();
@@ -729,7 +764,7 @@ impl Game {
                         let wanted = (ongoing_sales_score as f32
                             * presence_sum
                             * UNITS_PER_SCORE_POINT) as u32
-                            / 5;
+                            / TAIL_UNITS_DIVISOR;
                         let mut units = wanted;
                         let mut stock_capped = false;
                         if release.copies_pressed > 0 {
@@ -787,9 +822,15 @@ impl Game {
             }
         }
 
-        // Apply all collected certifications.
+        // Apply all collected certifications. On the tail path the 🏆 lines
+        // log right away — the sales that earned them happened in earlier
+        // weeks, so there is no same-pass cause line to wait for.
         for (release_name, old_level, new_level, copies_sold) in certifications_to_award {
-            self.apply_certification_awards(old_level, new_level, &release_name, copies_sold);
+            let lines =
+                self.apply_certification_awards(old_level, new_level, &release_name, copies_sold);
+            for line in lines {
+                self.log(line);
+            }
         }
 
         // M5 (§E-1, label half — tail path): re-press the signed releases that

--- a/src/game/events_apply.rs
+++ b/src/game/events_apply.rs
@@ -112,7 +112,9 @@ impl Game {
                 }
             }
             _ => match rng.gen_range(0..3) {
-                0 => self.band.gain_fame(1),
+                0 => {
+                    self.band.gain_fame(1);
+                }
                 1 => self.player.money += rng.gen_range(50..200),
                 _ => {
                     self.band.reputation.critical_acclaim =

--- a/src/game/sim.rs
+++ b/src/game/sim.rs
@@ -637,7 +637,10 @@ fn observe(career: &mut Career, game: &Game, had_deal: &mut bool) {
     if signed
         && career.deals_signed == 1
         && career.first_deal_recoup_week.is_none()
-        && game.band.current_deal().is_some_and(|deal| deal.unrecouped <= 0)
+        && game
+            .band
+            .current_deal()
+            .is_some_and(|deal| deal.unrecouped <= 0)
     {
         career.first_deal_recoup_week = Some(game.week);
     }
@@ -899,7 +902,8 @@ fn median_signed_act_recoups_the_advance_before_the_terms_halfway_mark() {
     let mut recoup_pct: Vec<u32> = Vec::new();
     for seed in 1..=SEEDS {
         let career = run_career(Bot::LabelLoyalist, seed, HORIZON);
-        let (Some(signed_week), Some(term)) = (career.first_deal_week, career.first_deal_term_weeks)
+        let (Some(signed_week), Some(term)) =
+            (career.first_deal_week, career.first_deal_term_weeks)
         else {
             continue;
         };

--- a/src/game/sim.rs
+++ b/src/game/sim.rs
@@ -92,6 +92,7 @@ pub(super) fn seeded_game(seed: u64) -> Game {
         turn_log: Vec::new(),
         rockstar_achieved: false,
         current_distribution_channel: music::DistributionChannel::default(),
+        last_sales_pass_week: None,
     };
     game.initialize_player("Sim Driver", "The Test Pattern", genre::MusicGenre::Rock);
     game
@@ -495,6 +496,13 @@ struct Career {
     /// did they actually make it").
     weeks_to_rockstar: Option<u32>,
     first_deal_week: Option<u32>,
+    /// Term length of the first deal signed (§E-4), stamped alongside
+    /// `first_deal_week`.
+    first_deal_term_weeks: Option<u16>,
+    /// Week the first deal's recoupment ledger (§E-2) first cleared — the
+    /// §F target reads this against the term's halfway mark. `None` if that
+    /// deal never recouped inside the horizon.
+    first_deal_recoup_week: Option<u32>,
     deals_signed: u32,
     sell_outs: u32,
     /// M7 (§E-4): contract breaches — a term ran out with albums owed.
@@ -535,6 +543,8 @@ fn drive(bot: Bot, game: &mut Game, horizon_weeks: u32) -> Career {
         weeks_to_fame_50: None,
         weeks_to_rockstar: None,
         first_deal_week: None,
+        first_deal_term_weeks: None,
+        first_deal_recoup_week: None,
         deals_signed: 0,
         sell_outs: 0,
         breaches: 0,
@@ -618,7 +628,18 @@ fn observe(career: &mut Career, game: &Game, had_deal: &mut bool) {
         career.deals_signed += 1;
         if career.first_deal_week.is_none() {
             career.first_deal_week = Some(game.week);
+            career.first_deal_term_weeks = game.band.current_deal().map(|deal| deal.term_weeks);
         }
+    }
+    // §F recoupment target: the week the FIRST deal's ledger clears. Only
+    // watched while that first deal is still the active one — a later deal's
+    // fresh (smaller) ledger must not masquerade as the first recouping.
+    if signed
+        && career.deals_signed == 1
+        && career.first_deal_recoup_week.is_none()
+        && game.band.current_deal().is_some_and(|deal| deal.unrecouped <= 0)
+    {
+        career.first_deal_recoup_week = Some(game.week);
     }
     *had_deal = signed;
     while career.fame_by_year.len() < (game.week / constants::WEEKS_PER_YEAR) as usize {
@@ -855,6 +876,50 @@ fn no_bot_panics_or_stalls_inside_five_years() {
             );
         }
     }
+}
+
+/// §F: "Median signed act recoups the advance before the term's halfway
+/// mark." This is the assertion whose absence let issue #20 slide: the M7
+/// sales rescale tripled the copies every pressing charges to the ledger
+/// while `SALES_INCOME_DIVISOR` kept royalty dollars flat, so below a 30%
+/// royalty the ledger grew monotonically and no signed act could ever
+/// recoup — and no test noticed. Label-loyalist careers, first deal each:
+/// the median ledger-clear point must land before 50% of the term. A deal
+/// that never recoups inside the horizon stays in the sample at an
+/// over-the-horizon percentage, dragging the median honestly instead of
+/// silently vanishing.
+#[test]
+fn median_signed_act_recoups_the_advance_before_the_terms_halfway_mark() {
+    // 8 years, not the 5-year smoke horizon: a first deal signed in year
+    // 3-4 needs its full term (up to 156 weeks) inside the window, or a
+    // healthy deal gets counted as "never recouped" purely because the
+    // clock ran out on the measurement.
+    const HORIZON: u32 = 8 * constants::WEEKS_PER_YEAR;
+    const SEEDS: u64 = 12;
+    let mut recoup_pct: Vec<u32> = Vec::new();
+    for seed in 1..=SEEDS {
+        let career = run_career(Bot::LabelLoyalist, seed, HORIZON);
+        let (Some(signed_week), Some(term)) = (career.first_deal_week, career.first_deal_term_weeks)
+        else {
+            continue;
+        };
+        let term = u32::from(term.max(1));
+        let recoup_week = career.first_deal_recoup_week.unwrap_or(HORIZON + term);
+        recoup_pct.push(recoup_week.saturating_sub(signed_week) * 100 / term);
+    }
+    assert!(
+        recoup_pct.len() >= SEEDS as usize * 2 / 3,
+        "the label-loyalist should sign on most seeds inside eight years; only {}/{SEEDS} did",
+        recoup_pct.len()
+    );
+    recoup_pct.sort_unstable();
+    println!("first-deal recoup points as % of term ({SEEDS} seeds): {recoup_pct:?}");
+    let median_pct = recoup_pct[recoup_pct.len() / 2];
+    assert!(
+        median_pct < 50,
+        "§F target: the median signed act must recoup the advance before the term's \
+         halfway mark; median recoup point was {median_pct}% of the term ({recoup_pct:?})"
+    );
 }
 
 /// With both story-event taps silenced (they can hand out fame), a band

--- a/src/game/tests/certifications.rs
+++ b/src/game/tests/certifications.rs
@@ -34,7 +34,7 @@ fn crossing_silver_threshold_awards_certification() {
     assert_eq!(cert_level, 1, "50,000 copies should be SILVER (level 1)");
 
     // Manually apply the awards to verify the bumps.
-    game.apply_certification_awards(0, 1, "Test Release", 50_000);
+    let _ = game.apply_certification_awards(0, 1, "Test Release", 50_000);
 
     // Check the bumps were applied.
     assert_eq!(
@@ -112,7 +112,7 @@ fn certification_bumps_are_correct_magnitude() {
     let initial_commercial = game.band.reputation.commercial_success;
 
     // Apply silver (level 0→1) awards
-    game.apply_certification_awards(0, 1, "Test Release", 50_000);
+    let _ = game.apply_certification_awards(0, 1, "Test Release", 50_000);
     assert_eq!(
         game.player.happiness,
         initial_happiness + 5,
@@ -128,7 +128,7 @@ fn certification_bumps_are_correct_magnitude() {
     let happiness_after_silver = game.player.happiness;
     let commercial_after_silver = game.band.reputation.commercial_success;
 
-    game.apply_certification_awards(1, 2, "Test Release", 150_000);
+    let _ = game.apply_certification_awards(1, 2, "Test Release", 150_000);
     assert_eq!(
         game.player.happiness,
         happiness_after_silver + 8,
@@ -144,7 +144,7 @@ fn certification_bumps_are_correct_magnitude() {
     let happiness_after_gold = game.player.happiness;
     let commercial_after_gold = game.band.reputation.commercial_success;
 
-    game.apply_certification_awards(2, 3, "Test Release", 400_000);
+    let _ = game.apply_certification_awards(2, 3, "Test Release", 400_000);
     assert_eq!(
         game.player.happiness,
         happiness_after_gold + 12,
@@ -165,7 +165,12 @@ fn multiplatinum_repeats_platinum_bumps() {
 
     // Apply platinum and then multi-platinum (×2 at 800k).
     // Levels 0 → 4 should include: silver (1), gold (2), platinum (3), then multi-platinum tier.
-    game.apply_certification_awards(0, 4, "Test Release", 800_000);
+    let lines = game.apply_certification_awards(0, 4, "Test Release", 800_000);
+    assert_eq!(
+        lines.len(),
+        4,
+        "one 🏆 line per level crossed: silver, gold, platinum, ×2 tier"
+    );
 
     // Silver: +5, Gold: +8, Platinum: +12, Multi-platinum ×1 tier: +12
     // Total: 5 + 8 + 12 + 12 = 37
@@ -191,7 +196,12 @@ fn incremental_multiplatinum_awards_one_tier_per_step() {
     let happiness = game.player.happiness;
     let commercial = game.band.reputation.commercial_success;
 
-    game.apply_certification_awards(4, 5, "Test Release", 1_200_000);
+    let lines = game.apply_certification_awards(4, 5, "Test Release", 1_200_000);
+    assert_eq!(
+        lines.len(),
+        1,
+        "×2 → ×3 crosses one tier: one 🏆 line, not two"
+    );
 
     assert_eq!(
         game.player.happiness,
@@ -214,7 +224,7 @@ fn happiness_and_reputation_cap_at_100() {
     game.band.reputation.commercial_success = 100;
 
     // Apply a certification bump (should stay at 100, not overflow)
-    game.apply_certification_awards(0, 3, "Test Release", 400_000);
+    let _ = game.apply_certification_awards(0, 3, "Test Release", 400_000);
 
     assert_eq!(game.player.happiness, 100, "Happiness should cap at 100");
     assert_eq!(

--- a/src/game/tests/recoupment.rs
+++ b/src/game/tests/recoupment.rs
@@ -249,6 +249,18 @@ fn certification_triggers_a_label_auto_repress() {
             .any(|m| m.contains("fresh run") && m.contains("certified")),
         "the auto-repress is announced as a certification restock"
     );
+    // Story order (issue #21's bug class): the sales line, then the award it
+    // earned, then the restock reacting to the award.
+    let position = |needle: &str| game.turn_log.iter().position(|m| m.contains(needle));
+    let sales = position("💿").expect("the sales line fires");
+    let cert = position("🏆").expect("the certification line fires");
+    let restock = position("fresh run").expect("the restock line fires");
+    assert!(
+        sales < cert && cert < restock,
+        "story order is sales → certified → restock; got 💿 at {sales}, 🏆 at {cert}, \
+         🏭 at {restock}: {:?}",
+        game.turn_log
+    );
 }
 
 /// The structural point of §E-1: a signed release with strong sustained tail
@@ -263,7 +275,11 @@ fn signed_release_re_presses_on_the_tail_and_can_certify() {
     // moves real volume across territories and can cross Silver.
     give_regional_presence(&mut game, 80);
     let mut deal = test_deal(90, 0.12);
-    deal.unrecouped = 0; // already recouped — watch the ledger grow with represses
+    // Deep in the red so the ledger never clears mid-test: the final balance
+    // then isolates the repress outlays exactly (start − royalties + outlays),
+    // instead of depending on whether that week's royalty out-earned that
+    // week's fresh run — which is tuning, not the mechanism under test.
+    deal.unrecouped = 1_000_000;
     game.band.record_deal = Some(deal);
 
     let first_run = 90 * LABEL_PRESSING_PER_REACH + 70 * LABEL_PRESSING_PER_FAME;
@@ -305,9 +321,17 @@ fn signed_release_re_presses_on_the_tail_and_can_certify() {
         "and it therefore certifies (level {})",
         release.certified
     );
+    // Every royalty dollar went to the ledger (still deep in the red), so
+    // without the repress outlays the balance would sit at exactly
+    // `start − royalties`; sitting strictly above that is the fresh runs'
+    // pressing costs having joined the ledger.
+    let royalties = release.total_income_generated as i32;
     assert!(
-        game.band.current_deal().unwrap().unrecouped > 0,
-        "each fresh run's pressing cost joined the recoupment ledger"
+        game.band.current_deal().unwrap().unrecouped > 1_000_000 - royalties,
+        "each fresh run's pressing cost joined the recoupment ledger on top of \
+         the royalty paydown: balance {} vs {} without outlays",
+        game.band.current_deal().unwrap().unrecouped,
+        1_000_000 - royalties
     );
 }
 

--- a/src/game/tests/releases.rs
+++ b/src/game/tests/releases.rs
@@ -288,3 +288,117 @@ fn post_launch_marketing_increases_catalog_tail_sales() {
         income_without_marketing
     );
 }
+
+/// Issue #21: when a signed first run sells out, the log must read in story
+/// order — 💿 sales → 📦 sold out → 🏭 restock — and the 📦 line must report
+/// the run that actually sold out, not the ledger-inflated post-re-press
+/// count (the auto-repress mutates `copies_pressed` before the lines are
+/// emitted).
+#[test]
+fn sold_out_log_reports_the_first_run_and_precedes_the_restock() {
+    let mut game = test_game();
+    game.band.fame = 60;
+    // M10: a touring act's regional presence so demand blows past a tiny run.
+    give_regional_presence(&mut game, 80);
+    game.band.record_deal = Some(test_deal(70, 0.12));
+
+    let mut release = test_release(1, ReleaseType::Single);
+    release.release_quality = 90;
+    release.week_released = 0;
+    release.copies_pressed = 500; // tiny run — demand will blow past it
+    game.just_released_music.push(release);
+
+    game.week = INITIAL_SALES_WINDOW_WEEKS;
+    game.process_music_releases_and_marketing();
+
+    let position = |needle: &str| game.turn_log.iter().position(|m| m.contains(needle));
+    let sales = position("💿").expect("the sales line fires");
+    let sold_out = position("📦").expect("the sold-out line fires");
+    let restock = position("fresh run").expect("the restock line fires");
+    assert!(
+        game.turn_log[sold_out].contains("all 500 copies gone"),
+        "📦 reports the run that sold out, not the post-re-press total: {}",
+        game.turn_log[sold_out]
+    );
+    assert!(
+        sales < sold_out && sold_out < restock,
+        "story order is sales → sold out → restock; got 💿 at {sales}, 📦 at {sold_out}, \
+         🏭 at {restock}: {:?}",
+        game.turn_log
+    );
+}
+
+/// Issue #20's bug class, player side: the per-copy pressing bill must stay
+/// coupled to the M7 sales rescale. A fully-sold pressing run — any tier,
+/// single or album — must out-earn its own bill in EVERY era, no matter the
+/// era's `recording_cost_modifier`. Before the fix, `PRESSING_PER_COPY_ALBUM`
+/// was still on the pre-M7 scale ($0.50 against $0.667/copy income), so a
+/// sold-out album run lost money unconditionally in every era with a cost
+/// modifier above 4/3 — five of the ten.
+#[test]
+fn a_fully_sold_pressing_run_out_earns_its_bill_in_every_era() {
+    let game = test_game();
+    for era in game.timeline.eras.values() {
+        let modifier = era.recording_cost_modifier;
+        for (tier, copies) in PRESSING_TIERS {
+            for (kind, setup, per_copy) in [
+                ("single", PRESSING_SETUP_SINGLE, PRESSING_PER_COPY_SINGLE),
+                ("album", PRESSING_SETUP_ALBUM, PRESSING_PER_COPY_ALBUM),
+            ] {
+                let bill = (setup + per_copy * copies as f32) * modifier;
+                // The most a run can ever earn: every pressed copy sold, at
+                // indie per-copy income after the M7 divisor.
+                let max_income = (copies * INDIE_INCOME_PER_COPY / SALES_INCOME_DIVISOR) as f32;
+                assert!(
+                    max_income > bill,
+                    "a fully-sold {kind} {tier} must out-earn its pressing bill in '{}' \
+                     (cost modifier {modifier}): income ${max_income} vs bill ${bill}",
+                    era.era_name
+                );
+            }
+        }
+    }
+}
+
+/// The weekly sales pass runs after EVERY action, but instant actions
+/// (marketing, lifestyle, re-press, deal responses) don't advance the
+/// calendar — a second pass in the same week must be a no-op, or every
+/// instant action mints a bonus catalog-tail week: free copies, income,
+/// recoupment paydown, and certification progress.
+#[test]
+fn the_sales_pass_resolves_at_most_once_per_week() {
+    let mut game = test_game();
+    game.band.fame = 50;
+    give_regional_presence(&mut game, 80);
+
+    let mut release = test_release(1, ReleaseType::Single);
+    release.week_released = 1;
+    release.initial_sales_score = 500; // a healthy tail
+    release.copies_pressed = 0; // uncapped
+    game.band.singles_released.push(release);
+
+    game.week = 10;
+    game.process_music_releases_and_marketing();
+    let sold_after_first = game.band.singles_released[0].copies_sold;
+    let income_after_first = game.band.singles_released[0].total_income_generated;
+    assert!(sold_after_first > 0, "the tail moved copies on the first pass");
+
+    // Same week again — the instant-action path. Nothing may move.
+    game.process_music_releases_and_marketing();
+    assert_eq!(
+        game.band.singles_released[0].copies_sold, sold_after_first,
+        "a second pass in the same week must not sell more copies"
+    );
+    assert_eq!(
+        game.band.singles_released[0].total_income_generated, income_after_first,
+        "a second pass in the same week must not mint more income"
+    );
+
+    // Next week the tail sells again.
+    game.week = 11;
+    game.process_music_releases_and_marketing();
+    assert!(
+        game.band.singles_released[0].copies_sold > sold_after_first,
+        "the following week's pass still sells"
+    );
+}

--- a/src/game/tests/releases.rs
+++ b/src/game/tests/releases.rs
@@ -261,15 +261,17 @@ fn post_launch_marketing_increases_catalog_tail_sales() {
     game.process_music_releases_and_marketing();
     let income_without_marketing = game.band.singles_released[0].total_income_generated;
 
-    // Reset income and copies sold for second test.
+    // Reset income and copies sold for the second pass, and re-arm the
+    // once-per-week guard so the SAME week replays with marketing — an
+    // adjacent-week comparison would confound the marketing bonus with the
+    // tail's own weekly decay whenever a divisor step lands between the two.
     game.band.singles_released[0].total_income_generated = 0;
     game.band.singles_released[0].copies_sold = 0;
+    game.last_sales_pass_week = None;
 
-    // Now add an active marketing campaign and run week 11.
-    game.week = 11;
     let campaign = music::ActiveMarketingCampaign {
         campaign_type: music::MarketingCampaignType::BasicPress,
-        start_week: 11,
+        start_week: 10,
         end_week: 15,
         effectiveness_bonus: 10,
     };
@@ -381,7 +383,10 @@ fn the_sales_pass_resolves_at_most_once_per_week() {
     game.process_music_releases_and_marketing();
     let sold_after_first = game.band.singles_released[0].copies_sold;
     let income_after_first = game.band.singles_released[0].total_income_generated;
-    assert!(sold_after_first > 0, "the tail moved copies on the first pass");
+    assert!(
+        sold_after_first > 0,
+        "the tail moved copies on the first pass"
+    );
 
     // Same week again — the instant-action path. Nothing may move.
     game.process_music_releases_and_marketing();


### PR DESCRIPTION
## Summary

Fixes #20 and #21, plus everything a sweep for their two bug classes (M7-rescale coupling misses; log-vs-mutation ordering) turned up. Bumps the release to **0.7.1**.

### Issue #20 — label recoupment structurally impossible
- `LABEL_RECOUP_PRESSING_PER_COPY` rescaled $0.30 → and then tuned to **$0.05/copy**. The issue's suggested $0.10 was calibrated while instant actions still re-ran the weekly sales pass (fixed below, inflating royalty velocity); with that exploit closed, $0.10 left the median first deal recouping at ~58% of its term. At $0.05 the median lands at **35%**, meeting the §F target.
- The missing §F sim-lab assertion now exists (`median_signed_act_recoups_the_advance_before_the_terms_halfway_mark`, 12 seeds × 8 years, CI-safe ~10s). Verified it **fails loudly at the old $0.30** (median 325% of term — i.e. never).

### Issue #21 — sold-out log contradictions
- The 📦 line now reports the run that actually sold out (pre-re-press count), and the 🏭 restock announcement is deferred to story order: 💿 sales → 📦 sold out → 🏭 restock. Mechanics untouched (the re-press still sizes and books to the ledger exactly where it did). Regression test pins the order and the reported count.

### Sweep findings, fixed
1. **Player-side pressing per-copy costs** (same rescale miss as #20): at pre-M7 $0.50/album vs post-M7 $0.667/copy income, a sold-out album run lost money **unconditionally** in every era with `recording_cost_modifier > 4/3` — five of ten. Both constants now divide by `SALES_INCOME_DIVISOR` (restores pre-M7 margins exactly). New test: a fully-sold run out-earns its bill in every era × tier × format.
2. **Label pressing run sizes** (third instance of the same class): runs are denominated in copies and were never tripled with M7's demand, so a signed first run nearly always sold out and the over-cap demand silently evaporated. `LABEL_PRESSING_PER_REACH/PER_FAME` 100/50 → 300/150.
3. **Instant actions minted bonus sales weeks**: the sales pass runs after every action, but marketing/lifestyle/re-press/deal-responses don't advance the week, so each re-sold a full catalog-tail week at that week's decay rate (free copies, income, paydown, cert progress). The pass now resolves at most once per game week (`last_sales_pass_week`, serde-defaulted for old saves). Regression test included.
4. **First-run certification news** logged before the sales that earned it (same class as #21): 🏆 lines are now deferred into story order (💿 → 📦 → 🏆 → 🏭).
5. **"fame +N" lines lied**: they printed the pre-multiplier gain, understating comeback gains 2× and overstating capped ones. `gain_fame`/`gain_fame_capped` now return the fame actually applied; gig/tour/support/record-sales lines and the Tour Report show it. Same for the tour's regional-fame line when the 100-cap eats part of the roll.

### Certification rebalance (follow-up commit)

Closing the bonus-sales exploit exposed that the §D/§F certification balance had been propped up by it: main's "med certs 5" was an artifact of both original bugs (broken recoupment → no renewal window → label churn into majors; double-sold early tails), and the exploit-free game allowed **zero** certifications for anyone — a probe showed best releases plateauing at 22–33k copies against Silver's 50k, so even §F's "a home-market act must still be able to reach Silver" failed. The catalog tail is retuned to put legitimate volume where the exploit-inflated volume effectively was: `TAIL_DIVISOR_WEEKS_PER_STEP` 3 → 4 and the tail unit rate /5 → /3 (now the named `TAIL_UNITS_DIVISOR`).

## Validation

- 188 tests pass; fmt and clippy clean.
- 15-year sweep (60 seeds × 7 bots): no panics, no breaches; **label-loyalist med certs 3 / max 18** (design target 1–3 silver, gold on hits); recouped signed act nets $1.81M vs indie's $1.28M ("worth signing, no longer free"); homebody still survives to a mansion; win rates in line with main.

## Smaller observations parked for a future design conversation

With recoupment working, the renewal window keeps a loyal act on its first label for a whole career (0.92 deals/run vs main's 2.78) — certs are healthy anyway, but a label-upgrading archetype might be worth a bot. Tours advance the calendar one week more than the 🚌 line advertises (`rest.rs` compensates for this pattern, `live.rs` doesn't). Advances are still sized against fame rather than projected recoupable royalties (#20's noted refinement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed release announcement ordering for certifications, sell-outs, and restocks, and corrected sell-out numbers to reflect the first run.
  * Prevented weekly sales-pass duplication so extra bonus catalog weeks can’t be created in the same week.
  * Corrected fame logs and reports so they match the actual fame gained after caps, bonuses, and regional limits.
  * Rebalanced pressing, recoupment, and indie/label economics to restore fair outcomes and make certifications properly reachable.
* **Chores**
  * Updated the game version to **0.7.1**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->